### PR TITLE
Fixes for outdated OSX clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,31 @@
 
 Library for processing on APR representation
 
-Dependencies:
+## Dependencies:
 
-* HDF5 library installed and the library linked/included (libhdf5-dev
+* HDF5 library installed and the library linked/included (libhdf5-dev)
 * CMake
 * tiffio (libtiff5-dev debian/ubuntu)
+
+## Building
+
+### OSX preliminaries
+
+OSX currently ships with an older version of clang that does not support OpenMP. A more current version (3.8+) has to be installed, e.g. via homebrew:
+
+```
+brew install llvm
+```
+
+All further cmake commands then have to be prepended by
+
+```
+CC="/usr/local/opt/llvm/bin/clang" CXX="/usr/local/opt/llvm/bin/clang++"
+LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+CPPFLAGS="-I/usr/local/opt/llvm/include" CXXFLAGS="-std=c++14"
+```
+
+### Compilation
 
 Compilation (out of source):
 
@@ -27,7 +47,7 @@ Developer dependencies (optional):
     sudo make
     sudo mv libg* /usr/lib/
 ```
-How to run tests?
+## How to run tests?
 
 Tests are stored in a submodule. Run these commands in order to run tests:
 

--- a/src/data_structures/Tree/Tree.hpp
+++ b/src/data_structures/Tree/Tree.hpp
@@ -98,7 +98,7 @@ public:
         for(unsigned int i = 0; i < NUMBEROFSONS; i++)
         {
 
-            coords3d new_coords = {(i & 2) != 0, i % 2, i > 3};
+            coords3d new_coords = {(i & 2) != 0, (int)i % 2, i > 3};
 
             tree[tofill + i] = current;
 
@@ -422,7 +422,7 @@ private:
                 for (unsigned int i = 0; i < NUMBEROFSONS; i++) {
 
                     coords3d new_coords = {2 * coords.x + ((i & 2) != 0),
-                                           2 * coords.y + i % 2,
+                                           2 * coords.y + (int)i % 2,
                                            2 * coords.z + (i > 3)};
 
                     if(child_in_image(new_coords, cell_elements)) {


### PR DESCRIPTION
This PR adds:
- casts where necessary to satisfy OSX' clang
- instructions how to build on OSX with an up-to-date version of llvm
