### PR TITLE
Changes to make OpenMP optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,13 @@ if(TESTS)
 endif(TESTS)
 
 
-find_package(OpenMP REQUIRED)
+find_package(OpenMP)
+if(NOT OPENMP_FOUND)
+    message("OpenMP support not found with current compiler. While APR can compile like this, performance might not be optimal. Please see README.md for instructions.")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_OPENMP ${OpenMP_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -DHAVE_OPENMP ${OpenMP_CXX_FLAGS}")
+endif()
 
 #set(_SAVED_HDF5_DIR ${HDF5_DIR})
 find_package(HDF5 REQUIRED)
@@ -92,8 +98,6 @@ set(SOURCE_FILES_COMPILED
 
 
 if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif(OPENMP_FOUND)
 
 
@@ -123,12 +127,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-
-    if (NOT NO_OPENMP)
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fopenmp")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fopenmp")
-    endif()
 endif()
 
 

--- a/benchmarks/analysis/apr_analysis.h
+++ b/benchmarks/analysis/apr_analysis.h
@@ -437,7 +437,9 @@ void test_local_scale(MeshData<uint16_t >& input_image,Part_rep& part_rep,PartCe
 
 
 
-#pragma omp parallel for default(shared)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared)
+#endif
     for(int i = 0; i < temp.mesh.size(); i++)
     {
         local_max.mesh[i] /= variance.mesh[i];
@@ -680,7 +682,9 @@ void cont_solution(MeshData<uint16_t >& input_image,Part_rep& part_rep,PartCellS
 
     int i,j,k;
 
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: cumsum)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: cumsum)
+#endif
     for(j = 0; j < gradient.z_num;j++){
         for(i = 0; i < gradient.x_num;i++){
 
@@ -974,7 +978,9 @@ void compare_E(MeshData<S>& org_img,MeshData<T>& rec_img,Proc_par& pars,std::str
     //ignored boundary layer
     int b = 0;
 
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: MSE) reduction(+: counter) reduction(+: mean) reduction(max: inf_norm)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: MSE) reduction(+: counter) reduction(+: mean) reduction(max: inf_norm)
+#endif
     for(j = b; j < (z_num_o-b);j++){
         for(i = b; i < (x_num_o-b);i++){
 
@@ -1005,7 +1011,9 @@ void compare_E(MeshData<S>& org_img,MeshData<T>& rec_img,Proc_par& pars,std::str
     double var = 0;
     counter = 0;
 
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: var) reduction(+: counter) reduction(+: MSE_var)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: var) reduction(+: counter) reduction(+: MSE_var)
+#endif
     for(j = b; j < (z_num_o-b);j++){
         for(i = b; i < (x_num_o-b);i++){
 

--- a/benchmarks/analysis/numerics_benchmarks.hpp
+++ b/benchmarks/analysis/numerics_benchmarks.hpp
@@ -237,7 +237,9 @@ void calc_mse(MeshData<S>& org_img,MeshData<T>& rec_img,std::string name,Analysi
     double MSE = 0;
     double L1 = 0;
 
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: MSE)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: MSE)
+#endif
     for(j = 0; j < z_num_o;j++){
         for(i = 0; i < x_num_o;i++){
 
@@ -257,7 +259,9 @@ void calc_mse(MeshData<S>& org_img,MeshData<T>& rec_img,std::string name,Analysi
 
     double var = 0;
     double counter = 0;
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: var) reduction(+: counter)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: var) reduction(+: counter)
+#endif
     for(j = 0; j < z_num_o;j++){
         for(i = 0; i < x_num_o;i++){
 
@@ -313,7 +317,9 @@ void calc_mse_debug(MeshData<S>& org_img,MeshData<T>& rec_img,std::string name,A
     MeshData<S> SE;
     SE.initialize(y_num_o,x_num_o,z_num_o,0);
 
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: MSE)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: MSE)
+#endif
     for(j = 0; j < z_num_o;j++){
         for(i = 0; i < x_num_o;i++){
 
@@ -332,7 +338,9 @@ void calc_mse_debug(MeshData<S>& org_img,MeshData<T>& rec_img,std::string name,A
 
     double var = 0;
     double counter = 0;
-#pragma omp parallel for default(shared) private(j,i,k) reduction(+: var) reduction(+: counter)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) reduction(+: var) reduction(+: counter)
+#endif
     for(j = 0; j < z_num_o;j++){
         for(i = 0; i < x_num_o;i++){
 

--- a/benchmarks/development/Example_alt_datastructures.cpp
+++ b/benchmarks/development/Example_alt_datastructures.cpp
@@ -119,7 +119,9 @@ int main(int argc, char **argv) {
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,y_coord) firstprivate(neigh_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,y_coord) firstprivate(neigh_keys) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
 
             curr_key = 0;
@@ -231,7 +233,9 @@ int main(int argc, char **argv) {
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
 
 
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_pc,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_pc,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -316,7 +320,9 @@ int main(int argc, char **argv) {
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
 
 
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_pc,node_val_part,curr_key,status,part_offset) firstprivate(neigh_part_keys,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_pc,node_val_part,curr_key,status,part_offset) firstprivate(neigh_part_keys,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;

--- a/benchmarks/development/Example_benchmark.cpp
+++ b/benchmarks/development/Example_benchmark.cpp
@@ -118,7 +118,9 @@ int main(int argc, char **argv) {
 
     for (int i = 0; i < num_repeats; ++i) {
 
-#pragma omp parallel for schedule(static) private(part) firstprivate(apr_parallel_iterator,neighbour_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(part) firstprivate(apr_parallel_iterator,neighbour_iterator)
+#endif
         for (part = 0; part < apr.total_number_particles(); ++part) {
             //needed step for any parallel loop (update to the next part)
             apr_parallel_iterator.set_iterator_to_particle_by_number(part);
@@ -142,8 +144,9 @@ int main(int argc, char **argv) {
     }
 
     timer.stop_timer();
+    std::chrono::duration<double> elapsed_seconds = timer.t2 - timer.t1;
 
-    std::cout << "New parallel iteration took: " << (timer.t2 - timer.t1)/(num_repeats*1.0) << std::endl;
+    std::cout << "New parallel iteration took: " << elapsed_seconds.count()/(num_repeats*1.0) << std::endl;
 
 
 

--- a/benchmarks/development/Tree/PartCellData.hpp
+++ b/benchmarks/development/Tree/PartCellData.hpp
@@ -1209,7 +1209,9 @@ public:
             const unsigned int z_num_ds = z_num[i - 1];
             const unsigned int y_num_ds = y_num[i - 1];
 
-#pragma omp parallel for default(shared) private(z_, x_, y_, curr_index, status, prev_ind) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, y_, curr_index, status, prev_ind) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = 0; z_ < z_num_; z_++) {
 
                 for (x_ = 0; x_ < x_num_; x_++) {
@@ -1242,7 +1244,9 @@ public:
             const unsigned int z_num_ds = z_num[i-1];
             const unsigned int y_num_ds = y_num[i-1];
 
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -1338,7 +1342,9 @@ public:
             const unsigned int z_num_ds = z_num[i-1];
             const unsigned int y_num_ds = y_num[i-1];
 
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -2025,7 +2031,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map_inplace)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,neigh_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,neigh_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -2080,7 +2088,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map_inplace)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,neigh_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,neigh_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -2458,7 +2468,9 @@ private:
                 
                 if (i == depth_min){
                     
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,j_neigh,y_neigh,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,j_neigh,y_neigh,y_coord) if(z_num_*x_num_ > 100)
+#endif
                     for(z_ = z_start;z_ < (z_num_-z_stop);z_++){
                         
                         for(x_ = x_start;x_ < (x_num_-x_stop);x_++){
@@ -2535,7 +2547,9 @@ private:
                     
                     
                 } else {
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,j_neigh,y_neigh,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,j_neigh,y_neigh,y_coord) if(z_num_*x_num_ > 100)
+#endif
                     for(z_ = z_start;z_ < (z_num_-z_stop);z_++){
                         
                         for(x_ = x_start;x_ < (x_num_-x_stop);x_++){
@@ -2676,7 +2690,9 @@ private:
                 
                 const unsigned int x_num_parent = x_num[i-1];
                 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,y_coord,node_val_parent) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,y_coord,node_val_parent) if(z_num_*x_num_ > 100)
+#endif
                 for(z_ = 0;z_ < (z_num_);z_++){
                     
                     for(x_ = 0;x_ < (x_num_);x_++){

--- a/benchmarks/development/Tree/PartCellParent.hpp
+++ b/benchmarks/development/Tree/PartCellParent.hpp
@@ -731,7 +731,9 @@ private:
                 const unsigned int x_num_ = neigh_info.x_num[i];
                 const unsigned int z_num_ = neigh_info.z_num[i];
                 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,j_neigh,y_neigh,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,y_parent,j_parent,j_neigh,y_neigh,y_coord) if(z_num_*x_num_ > 100)
+#endif
                 for(z_ = z_start;z_ < (z_num_-z_stop);z_++){
                     
                     for(x_ = x_start;x_ < (x_num_-x_stop);x_++){
@@ -888,7 +890,9 @@ private:
             const unsigned int z_num_ = pc_data.z_num[i];
             
             
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,y_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -1071,7 +1075,9 @@ private:
             const unsigned int z_num_ = pc_data.z_num[i];
             const unsigned int y_num_ = pc_data.  y_num[i];
             
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -1181,7 +1187,9 @@ private:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val) reduction(+:num_cells)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val) reduction(+:num_cells)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 for(x_ = 0;x_ < x_num_;x_++){

--- a/benchmarks/development/Tree/PartCellStructure.hpp
+++ b/benchmarks/development/Tree/PartCellStructure.hpp
@@ -151,7 +151,9 @@ private:
             const unsigned int y_num_ = y_num[i];
             
             
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -212,7 +214,9 @@ private:
             const unsigned int z_num_ = z_num[i];
             const unsigned int y_num_ = y_num[i];
             
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -330,7 +334,9 @@ private:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status) reduction(+:num_cells,num_parts)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status) reduction(+:num_cells,num_parts)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -467,7 +473,9 @@ private:
             const unsigned int y_num = part_map.layers[i].y_num;
             
             
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -530,7 +538,9 @@ private:
             const unsigned int z_num = pc_data.z_num[i];
             const unsigned int y_num = part_map.layers[i].y_num;
             
-#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,y_,curr_index,status,prev_ind,prev_coord) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -678,7 +688,9 @@ private:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -742,7 +754,9 @@ private:
             }
             
             // BOUNDARY/FILLER PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -811,7 +825,9 @@ private:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) reduction(+:num_cells,num_parts) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) reduction(+:num_cells,num_parts) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -875,7 +891,9 @@ private:
         for(uint64_t i = pc_data.depth_min;i <= pc_data.depth_max;i++){
             const unsigned int x_num_ = pc_data.x_num[i];
             const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 
@@ -904,7 +922,9 @@ private:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -1701,7 +1721,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -1765,7 +1787,9 @@ public:
             }
 
             // BOUNDARY/FILLER PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord,part_offset) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -1937,7 +1961,9 @@ public:
                 const unsigned int x_num_ = x_num[d-1];
                 const unsigned int z_num_ = z_num[d-1];
                 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,status,part_offset,x_p,y_p,z_p,depth_,status_,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,status,part_offset,x_p,y_p,z_p,depth_,status_,y_coord) if(z_num_*x_num_ > 100)
+#endif
                 for(z_ = 0;z_ < z_num_;z_++){
                     
                     curr_key = 0;
@@ -2109,7 +2135,9 @@ public:
         const unsigned int x_num_ = x_num[depth_max];
         const unsigned int z_num_ = z_num[depth_max];
         
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,status,part_offset,x_p,y_p,z_p,depth_,status_,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,curr_key,status,part_offset,x_p,y_p,z_p,depth_,status_,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             
             curr_key = 0;

--- a/benchmarks/development/Tree/ParticleData.hpp
+++ b/benchmarks/development/Tree/ParticleData.hpp
@@ -152,7 +152,9 @@ public:
             const unsigned int x_num = access_data.x_num[i];
             const unsigned int z_num = access_data.z_num[i];
             
-#pragma omp parallel for default(shared) private(z_,x_) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -176,7 +178,9 @@ public:
             const unsigned int x_num = access_data.x_num[i];
             const unsigned int z_num = access_data.z_num[i];
             
-#pragma omp parallel for default(shared) private(z_,x_,j_,status,node_val) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,status,node_val) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -675,7 +679,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -762,7 +768,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -878,7 +886,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -943,7 +953,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;

--- a/benchmarks/development/Tree/ParticleDataNew.hpp
+++ b/benchmarks/development/Tree/ParticleDataNew.hpp
@@ -215,7 +215,9 @@ public:
             temp_exist.resize(access_data.y_num[i]);
             temp_location.resize(access_data.y_num[i]);
             
-#pragma omp parallel for default(shared) private(j_,z_,x_,y_,node_val,status,z_seed,x_seed,node_val_part) firstprivate(temp_exist,temp_location) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j_,z_,x_,y_,node_val,status,z_seed,x_seed,node_val_part) firstprivate(temp_exist,temp_location) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -457,7 +459,9 @@ public:
             const unsigned int x_num = access_data.x_num[i];
             const unsigned int z_num = access_data.z_num[i];
             
-#pragma omp parallel for default(shared) private(z_,x_) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_) if(z_num*x_num > 100)
+#endif
             for(z_ = 0;z_ < z_num;z_++){
                 
                 for(x_ = 0;x_ < x_num;x_++){
@@ -477,7 +481,9 @@ public:
             const unsigned int z_num_ = access_data.z_num[depth];
             
             
-#pragma omp parallel for default(shared) private(z_,x_,j_)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_)  if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 
@@ -577,7 +583,9 @@ public:
             const unsigned int x_num_ = access_data.x_num[i];
             const unsigned int z_num_ = access_data.z_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,part_offset,node_val)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,part_offset,node_val)  if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -627,7 +635,9 @@ public:
             const unsigned int x_num_ = access_data.x_num[i];
             const unsigned int z_num_ = access_data.z_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,part_offset,node_val)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,part_offset,node_val)  if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -1176,7 +1186,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -1263,7 +1275,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -1379,7 +1393,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;
@@ -1444,7 +1460,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_pc,node_val_part,curr_key,part_offset,status,neigh_cell_keys,neigh_part_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 curr_key = 0;

--- a/benchmarks/development/old_algorithm/apr_pipeline.hpp
+++ b/benchmarks/development/old_algorithm/apr_pipeline.hpp
@@ -163,7 +163,9 @@ void calc_median_filter(MeshData<U>& input_img){
 
     uint64_t x_,z_;
 
-#pragma omp parallel for default(shared) private(z_,x_,offset_min,offset_max) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,offset_min,offset_max) firstprivate(temp_vec)
+#endif
     for(z_ = 0;z_ < z_num_m;z_++){
         //both z and x are explicitly accessed in the structure
 
@@ -195,7 +197,9 @@ void calc_median_filter(MeshData<U>& input_img){
     temp_vecm.resize(y_num_m);
 
 
-#pragma omp parallel for default(shared) private(z_,x_,offset_min,offset_max) firstprivate(temp_vec,temp_vecm,temp_vecp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,offset_min,offset_max) firstprivate(temp_vec,temp_vecm,temp_vecp)
+#endif
     for(z_ = 0;z_ < z_num_m;z_++){
         //both z and x are explicitly accessed in the structure
 
@@ -234,7 +238,9 @@ void calc_median_filter(MeshData<U>& input_img){
 
 
 
-#pragma omp parallel for default(shared) private(z_,x_,offset_min,offset_max) firstprivate(temp_vec,temp_vecm,temp_vecp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,offset_min,offset_max) firstprivate(temp_vec,temp_vecm,temp_vecp)
+#endif
     for(x_ = 0;x_ < x_num_m;x_++){
         //both z and x are explicitly accessed in the structure
 
@@ -298,7 +304,9 @@ void calc_median_filter_n(MeshData<U>& output_img,MeshData<U>& input_img){
 
     uint64_t x_,z_;
 
-#pragma omp parallel for default(shared) private(z_,x_,offset_min_x,offset_max_x,offset_min_y,offset_max_y,offset_min_z,offset_max_z)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,offset_min_x,offset_max_x,offset_min_y,offset_max_y,offset_min_z,offset_max_z)
+#endif
     for(z_ = 0;z_ < z_num_m;z_++){
         //both z and x are explicitly accessed in the structure
 
@@ -382,7 +390,9 @@ void calc_median_filter_n2(MeshData<U>& output_img,MeshData<U>& input_img){
 
     uint64_t x_,z_;
 
-#pragma omp parallel for default(shared) private(z_,x_,offset_min_x,offset_max_x,offset_min_y,offset_max_y,offset_min_z,offset_max_z)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,offset_min_x,offset_max_x,offset_min_y,offset_max_y,offset_min_z,offset_max_z)
+#endif
     for(z_ = 0;z_ < z_num_m;z_++){
         //both z and x are explicitly accessed in the structure
 
@@ -540,7 +550,9 @@ void spread_values(MeshData<S>& input_image){
     //float neigh_sum = 0;
 
 
-#pragma omp parallel for default(shared) private(j,i,k,i_n,k_n,j_n)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,i_n,k_n,j_n)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
                 for(k = 0;k < y_num;k++){
@@ -624,7 +636,9 @@ ExtraPartCellData<T> get_scale_parts_guided(APR<T>& apr,MeshData<S>& input_image
     const float step_size_y = pow(2, apr.y_vec.depth_max - depth);
     const float step_size_z = pow(2, apr.y_vec.depth_max - depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if(z_num_*x_num_ > 1000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if(z_num_*x_num_ > 1000)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -683,7 +697,9 @@ ExtraPartCellData<T> get_scale_parts_guided(APR<T>& apr,MeshData<S>& input_image
         const float step_size_z = pow(2, apr.y_vec.depth_max - depth);
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if(z_num_*x_num_ > 1000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if(z_num_*x_num_ > 1000)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -746,7 +762,9 @@ ExtraPartCellData<T> get_scale_parts(APR<T>& apr,MeshData<S>& input_image,Proc_p
         const float step_size_z = pow(2, apr.y_vec.depth_max - depth);
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if(z_num_*x_num_ > 1000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if(z_num_*x_num_ > 1000)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -1247,7 +1265,9 @@ void mask_variance(MeshData<float>& variance,MeshData<float>& temp,APR<float>& a
                 [](float x, float y) { return std::max(x,y); },
                 [](float x) { return x; });
     uint64_t i = 0;
-#pragma omp parallel for default(shared) private(i)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i)
+#endif
     for ( i = 0; i < variance.mesh.size(); ++i) {
 
         if(temp.mesh[i]==0){

--- a/benchmarks/development/old_algorithm/gradient.hpp
+++ b/benchmarks/development/old_algorithm/gradient.hpp
@@ -35,12 +35,16 @@ void calc_inv_bspline_y(MeshData<T>& input){
 
     int i, k, j;
 
-#pragma omp parallel for default(shared) private(i, k, j) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, j) firstprivate(temp_vec)
+#endif
     for(j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec[k] = input.mesh[j*x_num*y_num + i*y_num + k];
             }
@@ -49,7 +53,9 @@ void calc_inv_bspline_y(MeshData<T>& input){
             input.mesh[j*x_num*y_num + i*y_num] = a2*temp_vec[0];
             input.mesh[j*x_num*y_num + i*y_num] += (a1+a3)*temp_vec[1];
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 1; k < (y_num-1);k++){
                 input.mesh[j*x_num*y_num + i*y_num + k] = a1*temp_vec[k-1];
                 input.mesh[j*x_num*y_num + i*y_num + k] += a2*temp_vec[k];
@@ -93,8 +99,10 @@ void calc_inv_bspline_x(MeshData<T>& input){
 
     int i, k, jxnumynum, iynum;
 
-#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum) \
                          firstprivate(temp_vec)
+#endif
     for(int j = 0; j < z_num; j++){
 
         jxnumynum = j * x_num * y_num;
@@ -112,12 +120,16 @@ void calc_inv_bspline_x(MeshData<T>& input){
             iynum = i * y_num;
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num); k++) {
                 temp_vec[k].temp_3 = input.mesh[jxnumynum + iynum + y_num+ k];
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num); k++) {
                 input.mesh[jxnumynum + iynum + k] = a1 * temp_vec[k].temp_1 + a2 * temp_vec[k].temp_2 + a3 * temp_vec[k].temp_3;
             }
@@ -164,8 +176,10 @@ void calc_inv_bspline_z(MeshData<T>& input){
 
     int j, k, iynum, jxnumynum;
 
-#pragma omp parallel for default(shared) private(j, k, iynum, jxnumynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j, k, iynum, jxnumynum) \
                          firstprivate(temp_vec)
+#endif
     for (int i = 0; i < x_num; i++) {
 
         iynum = i * y_num;
@@ -181,17 +195,23 @@ void calc_inv_bspline_z(MeshData<T>& input){
             jxnumynum = j * xnumynum;
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec[k].temp_3 = input.mesh[jxnumynum + xnumynum + iynum + k];
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 input.mesh[jxnumynum + iynum + k] = a1 * temp_vec[k].temp_1 + a2 * temp_vec[k].temp_2 + a3 * temp_vec[k].temp_3;
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec[k].temp_1 = temp_vec[k].temp_2;
                 temp_vec[k].temp_2 = temp_vec[k].temp_3;
@@ -231,7 +251,9 @@ void calc_bspline_fd_y(MeshData<T>& input){
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -285,7 +307,9 @@ void calc_bspline_fd_x(MeshData<T>& input){
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(int j = 0;j < z_num;j++){
 
         //initialize the loop
@@ -356,7 +380,9 @@ void calc_bspline_fd_x_y_alt(MeshData<T>& input,MeshData<T>& grad,const float hx
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(k,i) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(k,i) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(int j = 0;j < z_num;j++){
 
         //initialize the loop
@@ -371,18 +397,24 @@ void calc_bspline_fd_x_y_alt(MeshData<T>& input,MeshData<T>& grad,const float hx
         for(i = 0;i < x_num-1;i++){
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec_3[k] = input.mesh[j*x_num*y_num + (i+1)*y_num + k];
             }
 
             //do the y gradient
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 1; k < (y_num-1);k++){
                 grad.mesh[j*x_num*y_num + i*y_num + k] = pow((a1*temp_vec_2[k-1] + a3*temp_vec_2[k+1])/hy,2.0);
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             //calc teh x gradient
             for (k = 0; k < (y_num);k++){
                 grad.mesh[j*x_num*y_num + i*y_num + k] += pow((a1*temp_vec_1[k] + a3*temp_vec_3[k])/hx,2.0);
@@ -431,7 +463,9 @@ void calc_bspline_fd_z_alt(MeshData<T>& input,MeshData<T>& grad,const float h){
     int k,j,index;
     int xnumynum = x_num * y_num;
 
-#pragma omp parallel for default(shared) private(k,j,index) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(k,j,index) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(int i = 0;i < x_num;i++){
 
         //initialize the loop
@@ -445,12 +479,16 @@ void calc_bspline_fd_z_alt(MeshData<T>& input,MeshData<T>& grad,const float h){
             index = j * x_num * y_num + i*y_num;
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec_3[k] = input.mesh[index + xnumynum +  k];
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 grad.mesh[index + k] = sqrt(grad.mesh[index + k] + pow((a1*temp_vec_1[k] + a3*temp_vec_3[k])/h,2.0f));
             }
@@ -496,7 +534,9 @@ void calc_bspline_fd_z(MeshData<T>& input){
 
     int j,k;
 
-#pragma omp parallel for default(shared) private(j, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(int i = 0;i < x_num;i++){
 
         //initialize the loop
@@ -669,7 +709,9 @@ void bspline_filt_rec_y(MeshData<T>& image,float lambda,float tol){
 
     int i, k, jxnumynum, iynum;
 
-#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp3, temp4, temp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp3, temp4, temp)
+#endif
     for(int j = 0;j < z_num;j++){
 
         jxnumynum = j * x_num * y_num;
@@ -718,7 +760,9 @@ void bspline_filt_rec_y(MeshData<T>& image,float lambda,float tol){
 
     btime.start_timer("backward_loop_y");
 
-#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp)
+#endif
     for(int j = z_num - 1; j >= 0; j--){
 
         jxnumynum = j * x_num * y_num;
@@ -859,8 +903,10 @@ void bspline_filt_rec_x(MeshData<T>& image,float lambda,float tol){
 
     int k, i, jxnumynum, index;
 
-#pragma omp parallel for default(shared) private(i, k, jxnumynum, index) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, jxnumynum, index) \
         firstprivate(temp_vec1, temp_vec2, temp_vec3, temp_vec4)
+#endif
     for(int j = 0;j < z_num; j++){
 
         std::fill(temp_vec1.begin(), temp_vec1.end(), 0);
@@ -915,7 +961,9 @@ void bspline_filt_rec_x(MeshData<T>& image,float lambda,float tol){
 
             index = i * y_num + jxnumynum;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = y_num - 1; k >= 0; k--) {
                 image.mesh[index + k] = image.mesh[index + k] + b1*temp_vec1[k]+  b2*temp_vec2[k];
             }
@@ -946,7 +994,9 @@ void bspline_filt_rec_x(MeshData<T>& image,float lambda,float tol){
 
             index = jxnumynum + i*y_num;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = y_num - 1; k >= 0; k--){
                 image.mesh[index + k] = image.mesh[index + k] + b1*temp_vec3[ k]+  b2*temp_vec4[ k];
                 temp_vec4[k] = temp_vec3[k];
@@ -1071,8 +1121,10 @@ void bspline_filt_rec_z(MeshData<T>& image,float lambda,float tol){
 
     int index, iynum, j, k;
 
-#pragma omp parallel for default(shared) private(j, k, iynum, index) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j, k, iynum, index) \
         firstprivate(temp_vec1, temp_vec2, temp_vec3, temp_vec4)
+#endif
     for(int i = 0; i < x_num; i++){
 
         std::fill(temp_vec1.begin(), temp_vec1.end(), 0);
@@ -1086,7 +1138,9 @@ void bspline_filt_rec_z(MeshData<T>& image,float lambda,float tol){
 
             index = j * x_num * y_num + iynum;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             //forwards boundary condition loop
             for (k = y_num - 1; k >= 0; k--){
 
@@ -1096,7 +1150,9 @@ void bspline_filt_rec_z(MeshData<T>& image,float lambda,float tol){
 
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             //backwards boundary condition loop
             for (k = y_num - 1; k >= 0; k--){
 
@@ -1129,7 +1185,9 @@ void bspline_filt_rec_z(MeshData<T>& image,float lambda,float tol){
 
             index = j * x_num * y_num + iynum;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < y_num; k++){
                 image.mesh[index + k] = image.mesh[index + k] + b1*temp_vec1[k]+  b2*temp_vec2[k];
             }
@@ -1160,7 +1218,9 @@ void bspline_filt_rec_z(MeshData<T>& image,float lambda,float tol){
 
             index = j * x_num * y_num + i * y_num;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = y_num - 1; k >= 0; k--){
                 image.mesh[index + k] = image.mesh[index + k] +  b1*temp_vec3[k]+  b2*temp_vec4[k];
                 temp_vec4[k] = temp_vec3[k];
@@ -1306,7 +1366,9 @@ void get_gradient_2D(Part_rep &p_rep, MeshData<T> &input_image, MeshData<T> &gra
 
     int i;
 
-#pragma omp parallel for default(shared) private(i)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i)
+#endif
     for (i = 0; i < grad_image.mesh.size(); ++i) {
         grad_image.mesh[i] = sqrt(grad_image.mesh[i]);
     }

--- a/benchmarks/development/old_algorithm/level.hpp
+++ b/benchmarks/development/old_algorithm/level.hpp
@@ -30,12 +30,16 @@ void compute_k_for_array(MeshData<T>& input,float k_factor,float rel_error){
 
     int i,k;
 
-#pragma omp parallel for default(shared) private (i,k) if(z_num*x_num*y_num > 100000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private (i,k) if(z_num*x_num*y_num > 100000)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
 
                 input.mesh[j*x_num*y_num + i*y_num + k] = asmlog_2(input.mesh[j*x_num*y_num + i*y_num + k]*mult_const);
@@ -71,7 +75,9 @@ void get_level_3D(MeshData<T> &var, MeshData<T> &grad_input, Part_rep &p_rep, Pa
     timer.start_timer("level_divide");
     //First need to divide the two grad and var, do this on the cpu
 
-#pragma omp parallel for default(shared)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared)
+#endif
     for(int i = 0; i < grad.mesh.size(); i++)
     {
         grad.mesh[i] /= var.mesh[i];
@@ -148,7 +154,9 @@ void get_level_2D(MeshData<T> &var, MeshData<T> &grad_input, Part_rep &p_rep, Pa
     timer.start_timer("level_divide");
     //First need to divide the two grad and var, do this on the cpu
 
-#pragma omp parallel for default(shared)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared)
+#endif
     for(int i = 0; i < grad.mesh.size(); i++)
     {
         grad.mesh[i] /= var.mesh[i];

--- a/benchmarks/development/old_algorithm/variance.hpp
+++ b/benchmarks/development/old_algorithm/variance.hpp
@@ -254,7 +254,9 @@ void calc_sat_mean_y(MeshData<T>& input,const int offset){
     int i, k, index;
     float counter, temp, divisor = 2*offset_n + 1;
 
-#pragma omp parallel for default(shared) private(i,k,counter,temp,index) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,counter,temp,index) firstprivate(temp_vec)
+#endif
     for(int j = 0;j < z_num;j++){
         for(i = 0;i < x_num;i++){
 
@@ -322,8 +324,10 @@ void calc_sat_mean_x(MeshData<T>& input,const int offset){
     float temp;
     int index_modulo, previous_modulo, current_index, jxnumynum;
 
-#pragma omp parallel for default(shared) private(i,k,temp,index_modulo, previous_modulo, current_index, jxnumynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,temp,index_modulo, previous_modulo, current_index, jxnumynum) \
         firstprivate(temp_vec)
+#endif
     for(int j = 0; j < z_num; j++) {
 
         jxnumynum = j * x_num * y_num;
@@ -402,8 +406,10 @@ void calc_sat_mean_z(MeshData<T>& input,const int offset) {
     int index_modulo, previous_modulo, current_index, iynum;
     int xnumynum = x_num * y_num;
 
-#pragma omp parallel for default(shared) private(j,k,temp,index_modulo, previous_modulo, current_index, iynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,k,temp,index_modulo, previous_modulo, current_index, iynum) \
         firstprivate(temp_vec)
+#endif
     for(int i = 0; i < x_num; i++) {
 
         iynum = i * y_num;
@@ -478,7 +484,9 @@ void calc_abs_diff(MeshData<T>& input_image,MeshData<T>& var){
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i,k)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -511,7 +519,9 @@ void intensity_th(MeshData<T>& input_image,MeshData<T>& var,const float threshol
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i,k)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -545,7 +555,9 @@ void rescale_var_and_threshold(MeshData<T>& var,const float var_rescale,Part_rep
     int i,k;
     float rescaled;
 
-#pragma omp parallel for default(shared) private(i,k,rescaled)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,rescaled)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){

--- a/benchmarks/development/old_io/partcell_io.h
+++ b/benchmarks/development/old_io/partcell_io.h
@@ -425,7 +425,9 @@ void write_apr_pc_struct_old(PartCellStructure<T,uint64_t>& pc_struct,std::strin
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
             
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -693,7 +695,9 @@ void write_apr_pc_struct(PartCellStructure<T,uint64_t>& pc_struct,std::string sa
         //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
         
         // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             
             for(x_ = 0;x_ < x_num_;x_++){
@@ -925,7 +929,9 @@ void write_apr_pc_struct_hilbert(PartCellStructure<T,uint64_t>& pc_struct,std::s
         //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
         // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
 
             for(x_ = 0;x_ < x_num_;x_++){
@@ -1468,7 +1474,9 @@ void write_apr_wavelet(PartCellStructure<T,uint64_t>& pc_struct,std::string save
         //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
         
         // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             
             for(x_ = 0;x_ < x_num_;x_++){

--- a/benchmarks/development/old_io/wavelet_comp.hpp
+++ b/benchmarks/development/old_io/wavelet_comp.hpp
@@ -290,7 +290,9 @@ void test_wavelet(PartCellStructure<T,uint64_t>& pc_struct,float th,int mlevel,W
         //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
         // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
 
             for(x_ = 0;x_ < x_num_;x_++){
@@ -531,7 +533,9 @@ void write_apr_wavelet(PartCellStructure<T,uint64_t>& pc_struct,std::string save
         //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
         // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
 
             for(x_ = 0;x_ < x_num_;x_++){
@@ -1145,7 +1149,9 @@ void write_apr_wavelet_partnew(PartCellStructure<T,uint64_t>& pc_struct,std::str
         //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
         // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,p,node_val_part,curr_key,part_offset,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
 
             for(x_ = 0;x_ < x_num_;x_++){

--- a/benchmarks/development/old_numerics/filter_numerics.hpp
+++ b/benchmarks/development/old_numerics/filter_numerics.hpp
@@ -119,7 +119,9 @@ static void particle_linear_neigh_access_alt_1(PartCellStructure<S,uint64_t>& pc
             neigh_y4.set_new_depth(curr_level,part_new);
             neigh_y5.set_new_depth(curr_level,part_new);
             
-#pragma omp parallel for default(shared) private(z_,x_,j_,int_neigh_p) firstprivate(curr_level,neigh_y,neigh_y1,neigh_y2,neigh_y3,neigh_y4,neigh_y5) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,int_neigh_p) firstprivate(curr_level,neigh_y,neigh_y1,neigh_y2,neigh_y3,neigh_y4,neigh_y5) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 
@@ -173,9 +175,9 @@ static void particle_linear_neigh_access_alt_1(PartCellStructure<S,uint64_t>& pc
     }
     
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1)/num_repeats;
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     std::cout << "Get neigh particle linear alt: " << time << std::endl;
     std::cout << "per 1000000 particles took: " << time/(1.0*pc_struct.get_number_parts()/1000000.0) << std::endl;
     
@@ -236,7 +238,9 @@ void lin_access_parts(PartCellStructure<S,uint64_t>& pc_struct){   //  Calculate
             const unsigned int x_num_ = pc_struct.pc_data.x_num[i];
             const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
             
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_pc,node_val_part,curr_key,status,part_offset)  firstprivate(neigh_part_keys,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_pc,node_val_part,curr_key,status,part_offset)  firstprivate(neigh_part_keys,neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 curr_key = 0;
@@ -309,9 +313,9 @@ void lin_access_parts(PartCellStructure<S,uint64_t>& pc_struct){   //  Calculate
     }
     
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1)/num_repeats;
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     std::cout << "Get Neigh Old: " << time << std::endl;
     
 }
@@ -354,7 +358,9 @@ static void neigh_cells(PartCellData<uint64_t>& pc_data){
             //loop over the resolutions of the structure
             const unsigned int x_num_ = pc_data.x_num[i];
             const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 curr_key = 0;
@@ -432,9 +438,9 @@ static void neigh_cells(PartCellData<uint64_t>& pc_data){
     
     
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1)/num_repeats;
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     std::cout << "Get neigh: " << time << std::endl;
     
    
@@ -486,7 +492,9 @@ static void particle_linear_neigh_access(PartCellStructure<float,uint64_t>& pc_s
             //loop over the resolutions of the structure
             const unsigned int x_num_ = pc_data.x_num[i];
             const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 curr_key = 0;
@@ -557,8 +565,8 @@ static void particle_linear_neigh_access(PartCellStructure<float,uint64_t>& pc_s
 
     
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
 
     analysis_data.add_float_data("neigh_part_linear_total",time);
     analysis_data.add_float_data("neigh_part_linear_perm",time/(1.0*pc_struct.get_number_parts()/1000000.0));
@@ -651,9 +659,9 @@ static void move_cells_random(PartCellData<uint64_t>& pc_data,ParticleDataNew<fl
     
     
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1)/(num_repeats/1000000.0);
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/(num_repeats/1000000.0);
+
     std::cout << "Particle Move random 1000000* : " << time << std::endl;
     
     
@@ -736,8 +744,9 @@ void pixels_move_random(PartCellStructure<U,uint64_t>& pc_struct,uint64_t y_num,
     (void) output_data.mesh;
     
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1);
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     std::cout << " Pixel Move random 1000000* : " << (x_num*y_num*z_num) << " took: " << time/(num_repeats/1000000.0) << std::endl;
     
 }
@@ -854,9 +863,9 @@ static void particle_random_access(PartCellStructure<float,uint64_t>& pc_struct,
 
 
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1);
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     timer.start_timer("neigh_cell_comp");
     
     
@@ -886,8 +895,9 @@ static void particle_random_access(PartCellStructure<float,uint64_t>& pc_struct,
     }
     
     timer.stop_timer();
-    
-    float time2 = (timer.t2 - timer.t1);
+
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time2 = elapsed_seconds.count()/num_repeats;
     //std::cout << "Overhead " << time2 << std::endl;
     
     //std::cout << "Random Access Neigh Particles: " << ((time-time2)) << std::endl;
@@ -930,7 +940,9 @@ MeshData<U> pixel_filter_full(MeshData<V>& input_data,std::vector<U>& filter,flo
 
     for(int r = 0;r < num_repeats;r++){
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -956,7 +968,8 @@ MeshData<U> pixel_filter_full(MeshData<V>& input_data,std::vector<U>& filter,flo
     (void) output_data.mesh;
 
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
 
     //std::cout << " Pixel Filter Size: " << (x_num*y_num*z_num) << " y took: " << time << std::endl;
 
@@ -964,7 +977,9 @@ MeshData<U> pixel_filter_full(MeshData<V>& input_data,std::vector<U>& filter,flo
 
     for(int r = 0;r < num_repeats;r++){
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -990,7 +1005,8 @@ MeshData<U> pixel_filter_full(MeshData<V>& input_data,std::vector<U>& filter,flo
     (void) output_data.mesh;
 
     timer.stop_timer();
-    float time2 = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time2 = elapsed_seconds.count()/num_repeats;
 
     //std::cout << " Pixel Filter Size: " << (x_num*y_num*z_num) << " x took: " << time2 << std::endl;
 
@@ -998,7 +1014,9 @@ MeshData<U> pixel_filter_full(MeshData<V>& input_data,std::vector<U>& filter,flo
 
     for(int r = 0;r < num_repeats;r++){
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -1025,7 +1043,8 @@ MeshData<U> pixel_filter_full(MeshData<V>& input_data,std::vector<U>& filter,flo
     (void) output_data.mesh;
 
     timer.stop_timer();
-    float time3 = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time3 = elapsed_seconds.count()/num_repeats;
 
     // std::cout << " Pixel Filter Size: " << (x_num*y_num*z_num) << " z took: " << time3 << std::endl;
 
@@ -1071,7 +1090,9 @@ MeshData<U> pixel_filter_full_mult(MeshData<V> input_data,std::vector<U> filter_
 
     for(int r = 0;r < num_repeats;r++){
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -1099,8 +1120,8 @@ MeshData<U> pixel_filter_full_mult(MeshData<V> input_data,std::vector<U> filter_
     (void) output_data.mesh;
 
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1)/num_repeats;
-
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
 
     std::swap(output_data.mesh,input_data.mesh);
 
@@ -1110,7 +1131,9 @@ MeshData<U> pixel_filter_full_mult(MeshData<V> input_data,std::vector<U> filter_
 
     for(int r = 0;r < num_repeats;r++){
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -1137,7 +1160,8 @@ MeshData<U> pixel_filter_full_mult(MeshData<V> input_data,std::vector<U> filter_
 
 
     timer.stop_timer();
-    float time2 = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time2 = elapsed_seconds.count()/num_repeats;
 
     std::swap(output_data.mesh,input_data.mesh);
 
@@ -1147,7 +1171,9 @@ MeshData<U> pixel_filter_full_mult(MeshData<V> input_data,std::vector<U> filter_
 
     for(int r = 0;r < num_repeats;r++){
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -1175,7 +1201,8 @@ MeshData<U> pixel_filter_full_mult(MeshData<V> input_data,std::vector<U> filter_
 
 
     timer.stop_timer();
-    float time3 = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time3 = elapsed_seconds.count()/num_repeats;
 
     // std::cout << " Pixel Filter Size: " << (x_num*y_num*z_num) << " z took: " << time3 << std::endl;
 
@@ -1226,7 +1253,9 @@ void pixels_linear_neigh_access(PartCellStructure<U,uint64_t>& pc_struct,uint64_
     
     for(int r = 0;r < num_repeats;r++){
         
-#pragma omp parallel for default(shared) private(j,i,k,i_n,k_n,j_n)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,i_n,k_n,j_n)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
                 for(k = 0;k < y_num;k++){
@@ -1258,8 +1287,9 @@ void pixels_linear_neigh_access(PartCellStructure<U,uint64_t>& pc_struct,uint64_
     }
     
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1)/num_repeats;
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     std::cout << "Pixel Linear Neigh: " << (x_num*y_num*z_num) << " took: " << time << std::endl;
     std::cout << "per 1000000 pixel took: " << (time)/((1.0*x_num*y_num*z_num)/1000000.0) << std::endl;
 
@@ -1345,8 +1375,9 @@ void pixel_neigh_random(PartCellStructure<U,uint64_t>& pc_struct,uint64_t y_num,
     }
     
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1);
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     timer.start_timer("full previous filter");
     
     for(int r = 0;r < num_repeats;r++){
@@ -1364,7 +1395,8 @@ void pixel_neigh_random(PartCellStructure<U,uint64_t>& pc_struct,uint64_t y_num,
     
     
     timer.stop_timer();
-    float time2 = (timer.t2 - timer.t1);
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time2 = elapsed_seconds.count();
 
     float est_full_time = (time-time2)*(1.0*x_num*y_num*z_num)/num_repeats;
     
@@ -1441,7 +1473,9 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
             CurrentLevel<float,uint64_t> curr_level;
             curr_level.set_new_depth(depth,part_new);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level,temp_vec) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level,temp_vec) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
 
@@ -1489,8 +1523,8 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
 
     timer.stop_timer();
 
-    float time_vec = (timer.t2 - timer.t1);
-
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time_vec = elapsed_seconds.count()/num_repeats;
 
     timer.start_timer("compute gradient y");
     
@@ -1507,7 +1541,9 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
             CurrentLevel<float,uint64_t> curr_level;
             curr_level.set_new_depth(depth,part_new);
             
-#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 
@@ -1556,9 +1592,10 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
     }
     
     timer.stop_timer();
-    
-    float time = (timer.t2 - timer.t1);
-    
+
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count();
+
     //std::cout << " Adaptive Filter y took: " << time/num_repeats << std::endl;
     
     for(int r = 0;r < num_repeats;r++){
@@ -1574,7 +1611,9 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
             CurrentLevel<float,uint64_t> curr_level;
             curr_level.set_new_depth(depth,part_new);
             
-#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 
@@ -1623,9 +1662,10 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
     }
     
     timer.stop_timer();
-    
-    float time2 = (timer.t2 - timer.t1);
-    
+
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time2 = elapsed_seconds.count();
+
     //std::cout << " Adaptive Filter x took: " << time2/num_repeats << std::endl;
     
     for(int r = 0;r < num_repeats;r++){
@@ -1641,7 +1681,9 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
             CurrentLevel<float,uint64_t> curr_level;
             curr_level.set_new_depth(depth,part_new);
             
-#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 
@@ -1690,7 +1732,8 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
     
     timer.stop_timer();
     
-    float time3 = (timer.t2 - timer.t1);
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time3 = elapsed_seconds.count();
 
 
     timer.start_timer("interp");
@@ -1701,7 +1744,8 @@ void apr_filter_full(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
     }
     timer.stop_timer();
 
-    float time_interp = (timer.t2 - timer.t1);
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_interp = elapsed_seconds.count();
 
     //std::cout << "Particle pc Filter z took: " << time3/num_repeats << std::endl;
     
@@ -1768,7 +1812,9 @@ ExtraPartCellData<U> sep_neigh_filter(PartCellData<uint64_t>& pc_data,ExtraPartC
                 //loop over the resolutions of the structure
                 const unsigned int x_num_ = pc_data.x_num[i];
                 const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
                 for (z_ = 0; z_ < z_num_; z_++) {
                     //both z and x are explicitly accessed in the structure
                     curr_key = 0;
@@ -1878,7 +1924,8 @@ ExtraPartCellData<U> sep_neigh_filter(PartCellData<uint64_t>& pc_data,ExtraPartC
     
     timer.stop_timer();
     
-    float time = (timer.t2 - timer.t1);
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count();
     
     std::cout << "Seperable Smoothing Filter: " << time << std::endl;
 
@@ -1961,7 +2008,9 @@ void new_filter_part(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
             CurrentLevel<float,uint64_t> curr_level;
             curr_level.set_new_depth(depth,part_new);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level,temp_vec) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,y_,offset_min,offset_max) firstprivate(curr_level,temp_vec) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
 
@@ -2003,7 +2052,8 @@ void new_filter_part(PartCellStructure<S,uint64_t>& pc_struct,uint64_t filter_of
 
     timer.stop_timer();
 
-    float time_vec = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time_vec = elapsed_seconds.count()/num_repeats;
 
     std::cout << "time: " << time_vec << std::endl;
 
@@ -2076,7 +2126,9 @@ ExtraPartCellData<U> filter_apr_by_slice(PartCellStructure<float,uint64_t>& pc_s
         set_zero_minus_1(filter_output);
 
         int i = 0;
-#pragma omp parallel for default(shared) private(i) firstprivate(slice) schedule(guided)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i) firstprivate(slice) schedule(guided)
+#endif
         for (i = 0; i < num_slices; ++i) {
             interp_slice(slice, y_vec, filter_input, dir, i);
 
@@ -2157,7 +2209,8 @@ ExtraPartCellData<U> filter_apr_input_img(MeshData<U>& input_img,PartCellStructu
 
     timer.stop_timer();
 
-    float time_y = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time_y = elapsed_seconds.count()/num_repeats;
 
     //std::swap(filter_input,filter_output);
 
@@ -2171,7 +2224,8 @@ ExtraPartCellData<U> filter_apr_input_img(MeshData<U>& input_img,PartCellStructu
 
     timer.stop_timer();
 
-    float time_x = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_x = elapsed_seconds.count()/num_repeats;
 
 
     //std::swap(filter_input,filter_output);
@@ -2186,7 +2240,8 @@ ExtraPartCellData<U> filter_apr_input_img(MeshData<U>& input_img,PartCellStructu
 
     timer.stop_timer();
 
-    float time_z = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_z = elapsed_seconds.count()/num_repeats;
 
     analysis_data.add_float_data("part_filter_input_y",time_y);
     analysis_data.add_float_data("part_filter_input_x",time_x);
@@ -2263,7 +2318,8 @@ ExtraPartCellData<U> filter_apr_by_slice(PartCellStructure<float,uint64_t>& pc_s
 
     timer.stop_timer();
 
-    float time_y = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time_y = elapsed_seconds.count()/num_repeats;
 
     //std::swap(filter_input,filter_output);
 
@@ -2277,7 +2333,8 @@ ExtraPartCellData<U> filter_apr_by_slice(PartCellStructure<float,uint64_t>& pc_s
 
     timer.stop_timer();
 
-    float time_x = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_x = elapsed_seconds.count()/num_repeats;
 
 
     //std::swap(filter_input,filter_output);
@@ -2292,7 +2349,8 @@ ExtraPartCellData<U> filter_apr_by_slice(PartCellStructure<float,uint64_t>& pc_s
 
     timer.stop_timer();
 
-    float time_z = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_z = elapsed_seconds.count()/num_repeats;
 
     analysis_data.add_float_data("part_filter_y",time_y);
     analysis_data.add_float_data("part_filter_x",time_x);
@@ -2373,7 +2431,8 @@ ExtraPartCellData<U> filter_apr_by_slice_mult(PartCellStructure<float,uint64_t>&
 
 
 
-    float time_y = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time_y = elapsed_seconds.count()/num_repeats;
 
     std::swap(filter_input,filter_output);
 
@@ -2389,7 +2448,8 @@ ExtraPartCellData<U> filter_apr_by_slice_mult(PartCellStructure<float,uint64_t>&
 
     timer.stop_timer();
 
-    float time_x = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_x = elapsed_seconds.count()/num_repeats;
 
 
 
@@ -2407,7 +2467,8 @@ ExtraPartCellData<U> filter_apr_by_slice_mult(PartCellStructure<float,uint64_t>&
 
     timer.stop_timer();
 
-    float time_z = (timer.t2 - timer.t1)/num_repeats;
+    elapsed_seconds = timer.t2 - timer.t1;
+    float time_z = elapsed_seconds.count()/num_repeats;
 
 
     analysis_data.add_float_data("part_filter_y",time_y);
@@ -2481,7 +2542,9 @@ ExtraPartCellData<U> sep_neigh_grad(PartCellData<uint64_t>& pc_data,ExtraPartCel
         //loop over the resolutions of the structure
         const unsigned int x_num_ = pc_data.x_num[i];
         const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -2598,7 +2661,8 @@ ExtraPartCellData<U> sep_neigh_grad(PartCellData<uint64_t>& pc_data,ExtraPartCel
 
     timer.stop_timer();
 
-    float time = (timer.t2 - timer.t1);
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count();
 
     //std::cout << "Seperable Smoothing Filter: " << time << std::endl;
     return filter_output;
@@ -2739,7 +2803,9 @@ ExtraPartCellData<std::array<float,3>> adaptive_gradient_normal(PartCellStructur
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 

--- a/benchmarks/development/old_numerics/graph_cut_seg.hpp
+++ b/benchmarks/development/old_numerics/graph_cut_seg.hpp
@@ -707,7 +707,9 @@ void construct_max_flow_graph_new(PartCellStructure<V,T>& pc_struct,GraphType& g
         const unsigned int x_num_ = pc_struct.pc_data.x_num[i];
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
 
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
 
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
@@ -846,7 +848,9 @@ void construct_max_flow_graph_new(PartCellStructure<V,T>& pc_struct,GraphType& g
         //loop over the resolutions of the structure
         const unsigned int x_num_ = pc_data.x_num[i];
         const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -1075,7 +1079,9 @@ void construct_max_flow_graph_new(PartCellStructure<V,T>& pc_struct,GraphType& g
         //loop over the resolutions of the structure
         const unsigned int x_num_ = pc_data.x_num[i];
         const unsigned int z_num_ = pc_data.z_num[i];
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_pc,curr_key)  firstprivate(neigh_cell_keys) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -1194,7 +1200,9 @@ void calc_graph_cuts_segmentation(PartCellStructure<V,T>& pc_struct,ExtraPartCel
         const unsigned int x_num_ = pc_struct.pc_data.x_num[i];
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
         
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;

--- a/benchmarks/development/old_numerics/misc_numerics.hpp
+++ b/benchmarks/development/old_numerics/misc_numerics.hpp
@@ -45,7 +45,9 @@ static void create_y_data(ExtraPartCellData<uint16_t>& y_vec,ParticleDataNew<flo
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -257,7 +259,9 @@ void interp_depth_to_mesh(MeshData<uint8_t>& k_img,PartCellStructure<S,uint64_t>
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
         
         
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -354,7 +358,9 @@ void interp_adapt_to_mesh(MeshData<uint8_t>& k_img,PartCellStructure<S,uint64_t>
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
 
 
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -449,7 +455,9 @@ void interp_status_to_mesh(MeshData<uint8_t>& status_img,PartCellStructure<S,uin
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
         
         
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -542,7 +550,9 @@ void interp_extrapc_to_mesh(MeshData<T>& output_img,PartCellStructure<S,uint64_t
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
         
         
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -653,7 +663,9 @@ void interp_parts_to_smooth(MeshData<U>& out_image,ExtraPartCellData<V>& interp_
     std::copy(k_img.mesh.begin(),k_img.mesh.end(),output_data.mesh.begin());
 
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max,filter_offset,factor)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max,filter_offset,factor)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -688,7 +700,9 @@ void interp_parts_to_smooth(MeshData<U>& out_image,ExtraPartCellData<V>& interp_
 
     std::copy(k_img.mesh.begin(),k_img.mesh.end(),output_data.mesh.begin());
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max,filter_offset,factor)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max,filter_offset,factor)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -727,7 +741,9 @@ void interp_parts_to_smooth(MeshData<U>& out_image,ExtraPartCellData<V>& interp_
 
     std::copy(k_img.mesh.begin(),k_img.mesh.end(),output_data.mesh.begin());
 
-#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max,filter_offset,factor)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,offset_min,offset_max,filter_offset,factor)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
 
@@ -792,7 +808,9 @@ void threshold_part(PartCellStructure<float,uint64_t>& pc_struct,ExtraPartCellDa
             FilterLevel<uint64_t,float> curr_level;
             curr_level.set_new_depth(depth,pc_struct);
             
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
                 //both z and x are explicitly accessed in the structure
                 
@@ -826,7 +844,8 @@ void threshold_part(PartCellStructure<float,uint64_t>& pc_struct,ExtraPartCellDa
     
     
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1)/num_repeats;
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
     
     std::cout << " Particle Threshold Size: " << pc_struct.get_number_parts() << " took: " << time << std::endl;
     
@@ -865,7 +884,9 @@ void threshold_pixels(PartCellStructure<U,uint64_t>& pc_struct,uint64_t y_num,ui
     
     for(int r = 0;r < num_repeats;r++){
         
-#pragma omp parallel for default(shared) private(j,i,k)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k)
+#endif
         for(j = 0; j < z_num;j++){
             for(i = 0; i < x_num;i++){
                 
@@ -881,8 +902,9 @@ void threshold_pixels(PartCellStructure<U,uint64_t>& pc_struct,uint64_t y_num,ui
     
     
     timer.stop_timer();
-    float time = (timer.t2 - timer.t1)/num_repeats;
-    
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
+    float time = elapsed_seconds.count()/num_repeats;
+
     std::cout << " Pixel Threshold Size: " << (x_num*y_num*z_num) << " took: " << time << std::endl;
     
 }
@@ -1057,7 +1079,9 @@ void interp_slice(PartCellStructure<float,uint64_t>& pc_struct,ExtraPartCellData
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -1085,7 +1109,9 @@ void interp_slice(PartCellStructure<float,uint64_t>& pc_struct,ExtraPartCellData
                         //add to all the required rays
 
                         for (int k = 0; k < step_size; ++k) {
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                             for (int i = 0; i < step_size; ++i) {
                                 //slice.mesh[dim1 + i + (dim2 + k)*slice.y_num] = temp_int;
 
@@ -1208,7 +1234,9 @@ void get_slices(PartCellStructure<float,uint64_t>& pc_struct){
         }
         int i = 0;
 
-#pragma omp parallel for default(shared) private(i) firstprivate(slice)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i) firstprivate(slice)
+#endif
         for (i = 0; i < num_slices; ++i) {
             interp_slice(slice, y_vec, part_new.particle_data, dir, i);
         }
@@ -1246,7 +1274,9 @@ void interp_img(MeshData<U>& img,ExtraPartCellData<uint16_t>& y_vec,ExtraPartCel
 
         const float step_size = pow(2,y_vec.depth_max - depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -1270,7 +1300,9 @@ void interp_img(MeshData<U>& img,ExtraPartCellData<uint16_t>& y_vec,ExtraPartCel
                         for (int q = dim3; q < offset_max_dim3; ++q) {
 
                             for (int k = dim2; k < offset_max_dim2; ++k) {
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                                 for (int i = dim1; i < offset_max_dim1; ++i) {
                                     img.mesh[i + (k) * img.y_num + q*img.y_num*img.x_num] = temp_int;
                                 }
@@ -1313,7 +1345,9 @@ void interp_depth(MeshData<U>& img,PartCellData<uint64_t>& pc_data,ParticleDataN
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -1340,7 +1374,9 @@ void interp_depth(MeshData<U>& img,PartCellData<uint64_t>& pc_data,ParticleDataN
                         for (int q = dim3; q < offset_max_dim3; ++q) {
 
                             for (int k = dim2; k < offset_max_dim2; ++k) {
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                                 for (int i = dim1; i < offset_max_dim1; ++i) {
                                     img.mesh[i + (k) * img.y_num + q*img.y_num*img.x_num] = depth;
                                 }
@@ -1391,7 +1427,9 @@ void interp_img(MeshData<U>& img,PartCellData<uint64_t>& pc_data,ParticleDataNew
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -1425,7 +1463,9 @@ void interp_img(MeshData<U>& img,PartCellData<uint64_t>& pc_data,ParticleDataNew
                         for (int q = dim3; q < offset_max_dim3; ++q) {
 
                             for (int k = dim2; k < offset_max_dim2; ++k) {
-    #pragma omp simd
+    #ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                                 for (int i = dim1; i < offset_max_dim1; ++i) {
                                     img.mesh[i + (k) * img.y_num + q*img.y_num*img.x_num] = temp_int;
                                 }
@@ -1585,7 +1625,9 @@ void weigted_interp_img(MeshData<U>& img,PartCellData<uint64_t>& pc_data,Particl
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -1715,7 +1757,9 @@ void weigted_interp_img(MeshData<U>& img,PartCellData<uint64_t>& pc_data,Particl
 
         const float step_size = pow(2, curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2042,7 +2086,9 @@ void set_zero_minus_1(ExtraPartCellData<V>& parts){
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2081,7 +2127,9 @@ void set_zero(ExtraPartCellData<V>& parts){
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2118,7 +2166,9 @@ void transform_parts(ExtraPartCellData<V>& parts,ExtraPartCellData<V>& parts2,Un
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2152,7 +2202,9 @@ void threshold_parts(ExtraPartCellData<V>& parts,ExtraPartCellData<U>& parts2,fl
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2194,7 +2246,9 @@ void threshold_parts(ExtraPartCellData<V>& parts,V th,V set_val,BinaryPredicate 
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2250,7 +2304,9 @@ ExtraPartCellData<V> transform_parts(ExtraPartCellData<V>& parts,UnaryOperator o
         const unsigned int z_num_min_ = 0;
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2291,7 +2347,9 @@ ExtraPartCellData<V> multiply_by_depth(ExtraPartCellData<V>& parts){
         const float step = pow(2,parts.depth_max - depth);
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2342,7 +2400,9 @@ ExtraPartCellData<V> multiply_by_dist_center(ExtraPartCellData<V>& parts,ExtraPa
         const float step = pow(2,parts.depth_max - depth);
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2413,7 +2473,9 @@ ExtraPartCellData<U> convert_cell_to_part(PartCellStructure<V,T>& pc_struct,Extr
         const unsigned int x_num_ = pc_struct.pc_data.x_num[i];
         const unsigned int z_num_ = pc_struct.pc_data.z_num[i];
 
-#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(p,z_,x_,j_,node_val_part,curr_key,status,part_offset) if(z_num_*x_num_ > 100)
+#endif
 
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
@@ -2595,7 +2657,9 @@ void interp_slice(MeshData<U>& slice,PartCellData<uint64_t>& pc_data,ParticleDat
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2636,7 +2700,9 @@ void interp_slice(MeshData<U>& slice,PartCellData<uint64_t>& pc_data,ParticleDat
 
 
                         for (int k = dim2; k < offset_max_dim2; ++k) {
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                             for (int i = dim1; i < offset_max_dim1; ++i) {
                                 slice.mesh[ i + (k)*slice.y_num] = temp_int;
 
@@ -2698,7 +2764,9 @@ static void create_y_offsets(ExtraPartCellData<uint16_t>& y_off,ParticleDataNew<
 
         const float step_size = pow(2,curr_level.depth_max - curr_level.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -2846,7 +2914,9 @@ void interp_slice(MeshData<U>& slice,ExtraPartCellData<uint16_t>& y_vec,ExtraPar
 
 
                     for (int k = dim2; k < offset_max_dim2; ++k) {
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                         for (int i = dim1; i < offset_max_dim1; ++i) {
                             slice.mesh[ i + (k)*slice.y_num] = temp_int;
 
@@ -2958,10 +3028,14 @@ void interp_slice_opt(MeshData<U>& slice,ExtraPartCellData<uint16_t>& y_vec,Extr
 
         const float step_size = pow(2,y_vec.depth_max - depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(dir == 1)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(dir == 1)
+#endif
         for (z_ = z_num_min_; z_ < z_num_max; z_++) {
             //both z and x are explicitly accessed in the structure
-#pragma omp parallel for default(shared) private(x_,j_) if(dir != 1)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(x_,j_) if(dir != 1)
+#endif
             for (x_ = x_num_min_; x_ < x_num_max; x_++) {
                 const unsigned int pc_offset = x_num_*z_ + x_;
 
@@ -3055,7 +3129,9 @@ void filter_apr_dir(ExtraPartCellData<uint16_t>& y_vec,ExtraPartCellData<U>& fil
     }
 
     int i = 0;
-#pragma omp parallel for default(shared) private(i) firstprivate(slice) schedule(static)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i) firstprivate(slice) schedule(static)
+#endif
     for (i = 0; i < num_slices; ++i) {
         interp_slice(slice, y_vec, filter_input, dir, i);
 
@@ -3077,7 +3153,9 @@ void get_slice(MeshData<U>& input_img,MeshData<U>& slice,const int dir,const int
         int i = 0;
         int j = 0;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
         for (int i = 0; i < slice.x_num; ++i) {
             for (int j = 0; j < slice.y_num; ++j) {
                 slice.mesh[j + i*slice.y_num] = input_img.mesh[j + i*input_img.y_num*input_img.x_num + num*input_img.y_num];
@@ -3089,7 +3167,9 @@ void get_slice(MeshData<U>& input_img,MeshData<U>& slice,const int dir,const int
         //xy
         slice.initialize(input_img.x_num, input_img.y_num, 1, 0);
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
         for (int i = 0; i < slice.x_num; ++i) {
             for (int j = 0; j < slice.y_num; ++j) {
                 slice.mesh[j + i*slice.y_num] = input_img.mesh[i + j*input_img.y_num + num*input_img.y_num*input_img.x_num];
@@ -3101,7 +3181,9 @@ void get_slice(MeshData<U>& input_img,MeshData<U>& slice,const int dir,const int
         //zy
         slice.initialize(input_img.z_num, input_img.y_num, 1, 0);
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
         for (int i = 0; i < slice.x_num; ++i) {
             for (int j = 0; j < slice.y_num; ++j) {
                 slice.mesh[j + i*slice.y_num] = input_img.mesh[i + j*input_img.y_num*input_img.x_num + num*input_img.y_num];
@@ -3146,7 +3228,9 @@ void filter_apr_mesh_dir(MeshData<U>& input_img,ExtraPartCellData<uint16_t>& y_v
     }
 
     int i = 0;
-#pragma omp parallel for default(shared) private(i) firstprivate(slice) schedule(guided)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i) firstprivate(slice) schedule(guided)
+#endif
     for (i = 0; i < num_slices; ++i) {
         get_slice(input_img,slice,dir,i);
 
@@ -3232,7 +3316,9 @@ void convert_from_old_structure(ExtraPartCellData<U>& particle_data,PartCellStru
         temp_exist.resize(pc_data.y_num[i]);
         temp_location.resize(pc_data.y_num[i]);
 
-#pragma omp parallel for default(shared) private(j_,z_,x_,y_,node_val,status,z_seed,x_seed,node_val_part) firstprivate(temp_exist,temp_location) if(z_num*x_num > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j_,z_,x_,y_,node_val,status,z_seed,x_seed,node_val_part) firstprivate(temp_exist,temp_location) if(z_num*x_num > 100)
+#endif
         for(z_ = 0;z_ < z_num;z_++){
 
             for(x_ = 0;x_ < x_num;x_++){

--- a/benchmarks/development/old_numerics/parent_numerics.hpp
+++ b/benchmarks/development/old_numerics/parent_numerics.hpp
@@ -139,7 +139,9 @@ void push_down_tree(PartCellStructure<U,T>& pc_struct,PartCellParent<T>& pc_pare
 
     curr_k = i;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part) firstprivate(children_keys,children_ind) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part) firstprivate(children_keys,children_ind) if(z_num_*x_num_ > 100)
+#endif
     for(z_ = 0;z_ < z_num_;z_++){
         //both z and x are explicitly accessed in the structure
         curr_key = 0;
@@ -270,7 +272,9 @@ void calc_cell_min_max(PartCellStructure<T,S>& pc_struct,PartCellParent<S>& pc_p
         const unsigned int z_num_ =  pc_parent.neigh_info.z_num[i];
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,part_offset,node_val_part) firstprivate(children_keys,children_ind) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,part_offset,node_val_part) firstprivate(children_keys,children_ind) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -372,7 +376,9 @@ void calc_cell_min_max(PartCellStructure<T,S>& pc_struct,PartCellParent<S>& pc_p
         const unsigned int z_num_ =  pc_parent.neigh_info.z_num[i];
 
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,part_offset,node_val_part) firstprivate(children_keys,children_ind) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,part_offset,node_val_part) firstprivate(children_keys,children_ind) if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -627,7 +633,9 @@ void smooth_parent_result_sep(PartCellParent<U>& pc_parent,ExtraPartCellData<T>&
         const unsigned int x_num_ =  pc_parent.neigh_info.x_num[i];
         const unsigned int z_num_ =  pc_parent.neigh_info.z_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part)  if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -673,7 +681,9 @@ void smooth_parent_result_sep(PartCellParent<U>& pc_parent,ExtraPartCellData<T>&
         const unsigned int x_num_ =  pc_parent.neigh_info.x_num[i];
         const unsigned int z_num_ =  pc_parent.neigh_info.z_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part)  if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;
@@ -718,7 +728,9 @@ void smooth_parent_result_sep(PartCellParent<U>& pc_parent,ExtraPartCellData<T>&
         const unsigned int x_num_ =  pc_parent.neigh_info.x_num[i];
         const unsigned int z_num_ =  pc_parent.neigh_info.z_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val_parent,curr_key,status,node_val_part)  if(z_num_*x_num_ > 100)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
             //both z and x are explicitly accessed in the structure
             curr_key = 0;

--- a/benchmarks/development/old_structures/particle_map.hpp
+++ b/benchmarks/development/old_structures/particle_map.hpp
@@ -84,8 +84,10 @@ private:
         for(int out = 0; out < std::min(3,z_num); out ++) {
 
 
-#pragma omp parallel for default(shared) private(j,i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         reduction(+:parts) if(z_num * x_num * y_num > 100000)
+#endif
             for (int j = out; j < z_num; j += 3) {
 
                 CHECKBOUNDARIES(0, j, z_num - 1, boundaries);
@@ -141,8 +143,10 @@ private:
         for(int out = 0; out < std::min(3,z_num); out ++) {
 
 
-#pragma omp parallel for default(shared) private(j,i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         reduction(+:parts) if(z_num * x_num * y_num > 100000)
+#endif
             for (int j = out; j < z_num; j += 3) {
 
                 CHECKBOUNDARIES(0, j, z_num - 1, boundaries);
@@ -203,8 +207,10 @@ private:
         // loop unrolling in order to avoid concurrent write
         for(int out = 0; out < std::min(3,z_num); out ++) {
 
-#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         if(z_num * x_num * y_num > 100000) schedule(static)
+#endif
             for (int j = out; j < z_num; j += 3) {
 
                 CHECKBOUNDARIES(0, j, z_num - 1, boundaries);
@@ -257,8 +263,10 @@ private:
         // loop unrolling in order to avoid concurrent write
         for(int out = 0; out < std::min(3,z_num); out ++) {
 
-#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         if(z_num * x_num * y_num > 100000) schedule(static)
+#endif
             for (int j = out; j < z_num; j += 3) {
 
                 CHECKBOUNDARIES(0, j, z_num - 1, boundaries);
@@ -313,8 +321,10 @@ private:
         // loop unrolling in order to avoid concurrent write
         for(int out = 0; out < std::min(3,z_num); out ++) {
 
-#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         if(z_num * x_num * y_num > 100000) schedule(static)
+#endif
             for (int j = out; j < z_num; j += 3) {
 
                 CHECKBOUNDARIES(0, j, z_num - 1, boundaries);
@@ -361,9 +371,11 @@ private:
         int i, k, jn, in, kn, children_index, index, parts=0;
         uint8_t children_status, status;
 
-#pragma omp parallel for default(shared) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) \
         private(i,k,children_index,jn,in,kn,children_status,status,index) \
         if(z_num * x_num * y_num > 10000) reduction(+:parts) firstprivate(level, children_boundaries)
+#endif
         for(int j = 0; j < z_num; j++) {
 
             if( j == z_num - 1 && prev_z_num % 2 ) {
@@ -430,9 +442,11 @@ private:
         int i, k, jn, in, kn, children_index, index, parts=0;
         uint8_t children_status, status;
 
-#pragma omp parallel for default(shared) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) \
         private(i,k,children_index,jn,in,kn,children_status,status,index) \
         if(z_num * x_num * y_num > 10000) reduction(+:parts) firstprivate(level, children_boundaries)
+#endif
         for(int j = 0; j < z_num; j++) {
 
             if( j == z_num - 1 && prev_z_num % 2 ) {
@@ -747,7 +761,9 @@ public :
 
         if (k == k_max){
             // k_max loop, has to include
-#pragma omp parallel for default(shared) private(i,q,temp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,q,temp)
+#endif
             for(int j = 0;j < z_num;j++){
                 for(i = 0;i < x_num;i++){
                     for (q = 0; q < (y_num);q++){
@@ -765,7 +781,9 @@ public :
 
         } else if (k == k_min){
         // k_max loop, has to include
-#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#endif
             for(int j = 0;j < z_num;j++){
                 for(i = 0;i < x_num;i++){
                     for (q = 0; q < (y_num);q++){
@@ -784,11 +802,15 @@ public :
         } else{
             // other k's
 
-#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#endif
             for(int j = 0;j < z_num;j++){
                 for(i = 0;i < x_num;i++){
 #ifndef _MSC_VER
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
 #endif
                     for (q = 0; q < y_num;q++){
 

--- a/benchmarks/development/old_structures/structure_parts.h
+++ b/benchmarks/development/old_structures/structure_parts.h
@@ -29,8 +29,11 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <chrono>
 
-#include "omp.h"
+#ifdef HAVE_OPENMP
+	#include "omp.h"
+#endif
 #include "benchmarks/development/old_io/parameters.h"
 
 class Part_map;
@@ -105,8 +108,8 @@ public:
     
     int timer_count;
     
-    double t1;
-    double t2;
+    std::chrono::system_clock::time_point t1;
+    std::chrono::system_clock::time_point t2;
     
     bool verbose_flag; //turn to true if you want all the functions to write out their timings to terminal
     
@@ -121,19 +124,20 @@ public:
     void start_timer(std::string timing_name){
         timing_names.push_back(timing_name);
         
-        t1 = omp_get_wtime();
+        t1 = std::chrono::system_clock::now();
     }
     
     
     void stop_timer(){
-        t2 = omp_get_wtime();
-        
-        timings.push_back(t2-t1);
+        t2 = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = t2 - t1;
+        timings.push_back(elapsed_seconds.count());
         
         if (verbose_flag){
             //output to terminal the result
             std::cout <<  timing_names[timer_count] << " took "
-            << t2-t1
+            << elapsed_seconds.count()
             << " seconds\n";
         }
         timer_count++;

--- a/src/algorithm/APRConverter.hpp
+++ b/src/algorithm/APRConverter.hpp
@@ -254,7 +254,9 @@ void APRConverter<ImageType>::get_local_particle_cell_set(MeshData<T>& grad_imag
     APRTimer timer;
 
     //divide gradient magnitude by Local Intensity Scale (first step in calculating the Local Resolution Estimate L(y), minus constants)
-#pragma omp parallel for default(shared)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared)
+#endif
     for(int i = 0; i < grad_temp.mesh.size(); i++)
     {
         local_scale_temp.mesh[i] = (1.0*grad_temp.mesh[i])/(local_scale_temp.mesh[i]*1.0);

--- a/src/algorithm/ComputeGradient.hpp
+++ b/src/algorithm/ComputeGradient.hpp
@@ -6,7 +6,9 @@
 #define PARTPLAY_GRADIENT_HPP
 
 #include "src/data_structures/Mesh/MeshData.hpp"
-#include "omp.h"
+#ifdef HAVE_OPENMP
+	#include "omp.h"
+#endif
 #include "src/algorithm/APRParameters.hpp"
 #include "src/misc/APRTimer.hpp"
 
@@ -101,7 +103,9 @@ void ComputeGradient::mask_gradient(MeshData<T>& grad_ds,MeshData<S>& temp_ds,Me
 
     uint64_t i = 0;
 
-#pragma omp parallel for default(shared) private(i)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i)
+#endif
     for ( i = 0; i < grad_ds.mesh.size(); ++i) {
 
         if(temp_ds.mesh[i]==0){
@@ -126,7 +130,9 @@ void ComputeGradient::threshold_gradient(MeshData<T>& grad,MeshData<S>& img,cons
     int i,k;
     float rescaled;
 
-#pragma omp parallel for default(shared) private(i,k,rescaled)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,rescaled)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -255,7 +261,9 @@ void ComputeGradient::bspline_filt_rec_y(MeshData<T>& image,float lambda,float t
 
     int i, k, jxnumynum, iynum;
 
-#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp3, temp4, temp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp3, temp4, temp)
+#endif
     for(int j = 0;j < z_num;j++){
 
         jxnumynum = j * x_num * y_num;
@@ -304,7 +312,9 @@ void ComputeGradient::bspline_filt_rec_y(MeshData<T>& image,float lambda,float t
 
     btime.start_timer("backward_loop_y");
 
-#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum, temp1, temp2, temp)
+#endif
     for(int j = z_num - 1; j >= 0; j--){
 
         jxnumynum = j * x_num * y_num;
@@ -446,8 +456,10 @@ void ComputeGradient::bspline_filt_rec_z(MeshData<T>& image,float lambda,float t
 
     int index, iynum, j, k;
 
-#pragma omp parallel for default(shared) private(j, k, iynum, index) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j, k, iynum, index) \
         firstprivate(temp_vec1, temp_vec2, temp_vec3, temp_vec4)
+#endif
     for(int i = 0; i < x_num; i++){
 
         std::fill(temp_vec1.begin(), temp_vec1.end(), 0);
@@ -461,7 +473,9 @@ void ComputeGradient::bspline_filt_rec_z(MeshData<T>& image,float lambda,float t
 
             index = j * x_num * y_num + iynum;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             //forwards boundary condition loop
             for (k = y_num - 1; k >= 0; k--){
 
@@ -471,7 +485,9 @@ void ComputeGradient::bspline_filt_rec_z(MeshData<T>& image,float lambda,float t
 
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             //backwards boundary condition loop
             for (k = y_num - 1; k >= 0; k--){
 
@@ -504,7 +520,9 @@ void ComputeGradient::bspline_filt_rec_z(MeshData<T>& image,float lambda,float t
 
             index = j * x_num * y_num + iynum;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < y_num; k++){
                 image.mesh[index + k] = image.mesh[index + k] + b1*temp_vec1[k]+  b2*temp_vec2[k];
             }
@@ -535,7 +553,9 @@ void ComputeGradient::bspline_filt_rec_z(MeshData<T>& image,float lambda,float t
 
             index = j * x_num * y_num + i * y_num;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = y_num - 1; k >= 0; k--){
                 image.mesh[index + k] = (image.mesh[index + k] +  b1*temp_vec3[k]+  b2*temp_vec4[k])*norm_factor;
                 temp_vec4[k] = temp_vec3[k];
@@ -661,8 +681,10 @@ void ComputeGradient::bspline_filt_rec_x(MeshData<T>& image,float lambda,float t
 
     int k, i, jxnumynum, index;
 
-#pragma omp parallel for default(shared) private(i, k, jxnumynum, index) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, jxnumynum, index) \
         firstprivate(temp_vec1, temp_vec2, temp_vec3, temp_vec4)
+#endif
     for(int j = 0;j < z_num; j++){
 
         std::fill(temp_vec1.begin(), temp_vec1.end(), 0);
@@ -717,7 +739,9 @@ void ComputeGradient::bspline_filt_rec_x(MeshData<T>& image,float lambda,float t
 
             index = i * y_num + jxnumynum;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = y_num - 1; k >= 0; k--) {
                 image.mesh[index + k] = image.mesh[index + k] + b1*temp_vec1[k]+  b2*temp_vec2[k];
             }
@@ -748,7 +772,9 @@ void ComputeGradient::bspline_filt_rec_x(MeshData<T>& image,float lambda,float t
 
             index = jxnumynum + i*y_num;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = y_num - 1; k >= 0; k--){
                 image.mesh[index + k] = (image.mesh[index + k] + b1*temp_vec3[ k]+  b2*temp_vec4[ k])*norm_factor;
                 temp_vec4[k] = temp_vec3[k];
@@ -787,8 +813,10 @@ void ComputeGradient::calc_inv_bspline_z(MeshData<T>& input){
 
     int j, k, iynum, jxnumynum;
 
-#pragma omp parallel for default(shared) private(j, k, iynum, jxnumynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j, k, iynum, jxnumynum) \
                          firstprivate(temp_vec)
+#endif
     for (int i = 0; i < x_num; i++) {
 
         iynum = i * y_num;
@@ -804,17 +832,23 @@ void ComputeGradient::calc_inv_bspline_z(MeshData<T>& input){
             jxnumynum = j * xnumynum;
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec[k].temp_3 = input.mesh[jxnumynum + xnumynum + iynum + k];
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 input.mesh[jxnumynum + iynum + k] = a1 * temp_vec[k].temp_1 + a2 * temp_vec[k].temp_2 + a3 * temp_vec[k].temp_3;
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec[k].temp_1 = temp_vec[k].temp_2;
                 temp_vec[k].temp_2 = temp_vec[k].temp_3;
@@ -858,8 +892,10 @@ void ComputeGradient::calc_inv_bspline_x(MeshData<T>& input){
 
     int i, k, jxnumynum, iynum;
 
-#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, iynum, jxnumynum) \
                          firstprivate(temp_vec)
+#endif
     for(int j = 0; j < z_num; j++){
 
         jxnumynum = j * x_num * y_num;
@@ -877,12 +913,16 @@ void ComputeGradient::calc_inv_bspline_x(MeshData<T>& input){
             iynum = i * y_num;
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num); k++) {
                 temp_vec[k].temp_3 = input.mesh[jxnumynum + iynum + y_num+ k];
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num); k++) {
                 input.mesh[jxnumynum + iynum + k] = a1 * temp_vec[k].temp_1 + a2 * temp_vec[k].temp_2 + a3 * temp_vec[k].temp_3;
             }
@@ -963,7 +1003,9 @@ void ComputeGradient::calc_bspline_fd_y(MeshData<T>& input){
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -1017,7 +1059,9 @@ void ComputeGradient::calc_bspline_fd_x(MeshData<T>& input){
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(int j = 0;j < z_num;j++){
 
         //initialize the loop
@@ -1106,7 +1150,9 @@ void ComputeGradient::calc_bspline_fd_ds_mag(MeshData<T> &input, MeshData<S> &gr
     int xnumynum = x_num * y_num;
 
 
-#pragma omp parallel for default(shared) private(k,i,j) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3,temp_vec_4,temp_vec_5,temp_vec_6)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(k,i,j) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3,temp_vec_4,temp_vec_5,temp_vec_6)
+#endif
     for(j = 0;j < z_num;j++){
 
         //initialize the loop
@@ -1123,14 +1169,18 @@ void ComputeGradient::calc_bspline_fd_ds_mag(MeshData<T> &input, MeshData<S> &gr
         for(i = 0;i < x_num-1;i++){
 
                 //initialize the z loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num); k++) {
                 temp_vec_4[k] = input.mesh[j_m*xnumynum + i * y_num + k];
                 temp_vec_5[k] = input.mesh[j_p*xnumynum +  i * y_num + k];
             }
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec_3[k] = input.mesh[j*x_num*y_num + (i+1)*y_num + k];
             }
@@ -1140,7 +1190,9 @@ void ComputeGradient::calc_bspline_fd_ds_mag(MeshData<T> &input, MeshData<S> &gr
             temp_vec_6[0] = sqrt(pow((a1*temp_vec_1[0] + a3*temp_vec_3[0])/hx,2.0)  + pow((a1*temp_vec_4[0] + a3*temp_vec_5[0])/hz,2.0));
 
             //do the y gradient
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 1; k < (y_num-1);k++){
                 temp_vec_6[k] =  sqrt(pow((a1*temp_vec_4[k] + a3*temp_vec_5[k])/hz,2.0) +  pow((a1*temp_vec_2[k-1] + a3*temp_vec_2[k+1])/hy,2.0) + pow((a1*temp_vec_1[k] + a3*temp_vec_3[k])/hx,2.0));
             }
@@ -1150,14 +1202,18 @@ void ComputeGradient::calc_bspline_fd_ds_mag(MeshData<T> &input, MeshData<S> &gr
             int j_2 = j/2;
             int i_2 = i/2;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num_ds);k++) {
                 grad.mesh[j_2*x_num_ds*y_num_ds + i_2*y_num_ds + k] = std::max(temp_vec_6[2*k],grad.mesh[j_2*x_num_ds*y_num_ds + i_2*y_num_ds + k]);
             }
 
             int k_s;
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num_ds);k++) {
                 k_s = std::min(2*k+1,y_num-1);
                 grad.mesh[j_2*x_num_ds*y_num_ds + i_2*y_num_ds + k] = std::max(temp_vec_6[2*k+1],grad.mesh[j_2*x_num_ds*y_num_ds + i_2*y_num_ds + k]);
@@ -1206,7 +1262,9 @@ void ComputeGradient::calc_bspline_fd_x_y_alt(MeshData<T>& input,MeshData<S>& gr
 
     int i,k,j;
 
-#pragma omp parallel for default(shared) private(k,i,j) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(k,i,j) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(j = 0;j < z_num;j++){
 
         //initialize the loop
@@ -1221,18 +1279,24 @@ void ComputeGradient::calc_bspline_fd_x_y_alt(MeshData<T>& input,MeshData<S>& gr
         for(i = 0;i < x_num-1;i++){
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec_3[k] = input.mesh[j*x_num*y_num + (i+1)*y_num + k];
             }
 
             //do the y gradient
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 1; k < (y_num-1);k++){
                 grad.mesh[j*x_num*y_num + i*y_num + k] = pow((a1*temp_vec_2[k-1] + a3*temp_vec_2[k+1])/hy,2.0);
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             //calc teh x gradient
             for (k = 0; k < (y_num);k++){
                 grad.mesh[j*x_num*y_num + i*y_num + k] += pow((a1*temp_vec_1[k] + a3*temp_vec_3[k])/hx,2.0);
@@ -1281,7 +1345,9 @@ void ComputeGradient::calc_bspline_fd_z_alt(MeshData<T>& input,MeshData<S>& grad
     int k,j,index,i;
     int xnumynum = x_num * y_num;
 
-#pragma omp parallel for default(shared) private(k,j,index,i) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(k,j,index,i) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(i = 0;i < x_num;i++){
 
         //initialize the loop
@@ -1295,12 +1361,16 @@ void ComputeGradient::calc_bspline_fd_z_alt(MeshData<T>& input,MeshData<S>& grad
             index = j * x_num * y_num + i*y_num;
 
             //initialize the loop
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec_3[k] = input.mesh[index + xnumynum +  k];
             }
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 grad.mesh[index + k] = sqrt(grad.mesh[index + k] + pow((a1*temp_vec_1[k] + a3*temp_vec_3[k])/h,2.0f));
             }
@@ -1346,7 +1416,9 @@ void ComputeGradient::calc_bspline_fd_z(MeshData<T>& input){
 
     int j,k;
 
-#pragma omp parallel for default(shared) private(j, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j, k) firstprivate(temp_vec_1, temp_vec_2, temp_vec_3)
+#endif
     for(int i = 0;i < x_num;i++){
 
         //initialize the loop
@@ -1414,12 +1486,16 @@ void ComputeGradient::calc_inv_bspline_y(MeshData<T>& input){
 
     int i, k, j;
 
-#pragma omp parallel for default(shared) private(i, k, j) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i, k, j) firstprivate(temp_vec)
+#endif
     for(j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 0; k < (y_num);k++){
                 temp_vec[k] = input.mesh[j*x_num*y_num + i*y_num + k];
             }
@@ -1428,7 +1504,9 @@ void ComputeGradient::calc_inv_bspline_y(MeshData<T>& input){
             input.mesh[j*x_num*y_num + i*y_num] = a2*temp_vec[0];
             input.mesh[j*x_num*y_num + i*y_num] += (a1+a3)*temp_vec[1];
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
             for (k = 1; k < (y_num-1);k++){
                 input.mesh[j*x_num*y_num + i*y_num + k] = a1*temp_vec[k-1];
                 input.mesh[j*x_num*y_num + i*y_num + k] += a2*temp_vec[k];

--- a/src/algorithm/LocalIntensityScale.hpp
+++ b/src/algorithm/LocalIntensityScale.hpp
@@ -50,7 +50,9 @@ void LocalIntensityScale::rescale_var_and_threshold(MeshData<T>& var,const float
     int i,k;
     float rescaled;
 
-#pragma omp parallel for default(shared) private(i,k,rescaled)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,rescaled)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -85,7 +87,9 @@ void LocalIntensityScale::calc_abs_diff(MeshData<T>& input_image,MeshData<T>& va
 
     int i,k;
 
-#pragma omp parallel for default(shared) private(i,k)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k)
+#endif
     for(int j = 0;j < z_num;j++){
 
         for(i = 0;i < x_num;i++){
@@ -164,7 +168,9 @@ void LocalIntensityScale::calc_sat_mean_y(MeshData<T>& input,const int offset){
     int i, k, index;
     float counter, temp, divisor = 2*offset_n + 1;
 
-#pragma omp parallel for default(shared) private(i,k,counter,temp,index) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,counter,temp,index) firstprivate(temp_vec)
+#endif
     for(int j = 0;j < z_num;j++){
         for(i = 0;i < x_num;i++){
 
@@ -232,8 +238,10 @@ void LocalIntensityScale::calc_sat_mean_x(MeshData<T>& input,const int offset){
     float temp;
     int index_modulo, previous_modulo, current_index, jxnumynum;
 
-#pragma omp parallel for default(shared) private(i,k,temp,index_modulo, previous_modulo, current_index, jxnumynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,temp,index_modulo, previous_modulo, current_index, jxnumynum) \
         firstprivate(temp_vec)
+#endif
     for(int j = 0; j < z_num; j++) {
 
         jxnumynum = j * x_num * y_num;
@@ -312,8 +320,10 @@ void LocalIntensityScale::calc_sat_mean_z(MeshData<T>& input,const int offset) {
     int index_modulo, previous_modulo, current_index, iynum;
     int xnumynum = x_num * y_num;
 
-#pragma omp parallel for default(shared) private(j,k,temp,index_modulo, previous_modulo, current_index, iynum) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,k,temp,index_modulo, previous_modulo, current_index, iynum) \
         firstprivate(temp_vec)
+#endif
     for(int i = 0; i < x_num; i++) {
 
         iynum = i * y_num;

--- a/src/algorithm/LocalParticleCellSet.hpp
+++ b/src/algorithm/LocalParticleCellSet.hpp
@@ -38,12 +38,16 @@ public:
 
         int i,k;
 
-#pragma omp parallel for default(shared) private (i,k) if(z_num*x_num*y_num > 100000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private (i,k) if(z_num*x_num*y_num > 100000)
+#endif
         for(int j = 0;j < z_num;j++){
 
             for(i = 0;i < x_num;i++){
 
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                 for (k = 0; k < (y_num);k++){
                     input.mesh[j*x_num*y_num + i*y_num + k] = asmlog_2(input.mesh[j*x_num*y_num + i*y_num + k]*mult_const);
                 }

--- a/src/algorithm/PullingScheme.hpp
+++ b/src/algorithm/PullingScheme.hpp
@@ -17,7 +17,9 @@
 #include "src/data_structures/Mesh/MeshData.hpp"
 #include "src/data_structures/APR/APR.hpp"
 
-#include "omp.h"
+#ifdef HAVE_OPENMP
+	#include "omp.h"
+#endif
 
 #define EMPTY 0
 #define SEED_TYPE 1
@@ -163,7 +165,9 @@ void PullingScheme::fill(float k, MeshData<T>& input)
 
     if (k == l_max){
         // k_max loop, has to include
-#pragma omp parallel for default(shared) private(i,q,temp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,q,temp)
+#endif
         for(int j = 0;j < z_num;j++){
             for(i = 0;i < x_num;i++){
                 for (q = 0; q < (y_num);q++){
@@ -181,7 +185,9 @@ void PullingScheme::fill(float k, MeshData<T>& input)
 
     } else if (k == l_min){
         // k_max loop, has to include
-#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#endif
         for(int j = 0;j < z_num;j++){
             for(i = 0;i < x_num;i++){
                 for (q = 0; q < (y_num);q++){
@@ -200,11 +206,15 @@ void PullingScheme::fill(float k, MeshData<T>& input)
     } else{
         // other k's
 
-#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,q,temp) if(z_num*x_num*y_num > 100000)
+#endif
         for(int j = 0;j < z_num;j++){
             for(i = 0;i < x_num;i++){
 #ifndef _MSC_VER
-#pragma omp simd
+#ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
 #endif
                 for (q = 0; q < y_num;q++){
 
@@ -252,8 +262,10 @@ void PullingScheme::set_ascendant_neighbours(int level)
     // loop unrolling in order to avoid concurrent write
     for(int out = 0; out < std::min(3,z_num); out ++) {
 
-#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         if(z_num * x_num * y_num > 100000) schedule(static)
+#endif
         for (int j = out; j < z_num; j += 3) {
 
             CHECKBOUNDARIES(0, j, z_num - 1, boundaries);
@@ -303,9 +315,11 @@ void PullingScheme::set_filler(int level)
     int i, k, jn, in, kn, children_index, index, parts=0;
     uint8_t children_status, status;
 
-#pragma omp parallel for default(shared) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) \
         private(i,k,children_index,jn,in,kn,children_status,status,index) \
         if(z_num * x_num * y_num > 10000) firstprivate(level, children_boundaries)
+#endif
     for(int j = 0; j < z_num; j++) {
 
         if( j == z_num - 1 && prev_z_num % 2 ) {
@@ -368,8 +382,10 @@ void PullingScheme::fill_neighbours(int level)
     for(int out = 0; out < std::min(3,z_num); out ++) {
 
 
-#pragma omp parallel for default(shared) private(j,i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k,neighbour_index,jn,in,kn,status,index) firstprivate(boundaries) \
         if(z_num * x_num * y_num > 100000)
+#endif
         for (int j = out; j < z_num; j += 3) {
 
             CHECKBOUNDARIES(0, j, z_num - 1, boundaries);

--- a/src/data_structures/APR/APR.hpp
+++ b/src/data_structures/APR/APR.hpp
@@ -235,7 +235,9 @@ public:
         parts.data.resize(apr_iterator.total_number_particles());
 
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             //needed step for any parallel loop (update to the next part)
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
@@ -261,7 +263,9 @@ public:
 
         parts.data.resize(apr_iterator.total_number_particles());
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             //needed step for any parallel loop (update to the next part)
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
@@ -301,7 +305,9 @@ private:
 
             const float step_size = pow(2, curr_level_l.depth_max - curr_level_l.depth);
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level_l) reduction(+:counter_parts) reduction(+:counter_elements)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) firstprivate(curr_level_l) reduction(+:counter_parts) reduction(+:counter_elements)  if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -370,7 +376,9 @@ private:
             curr_level_l.set_new_depth(depth, pc_data);
 
             const float step_size = pow(2, curr_level_l.depth_max - curr_level_l.depth);
-#pragma omp parallel for default(shared) private(z_,x_,j_,counter_parts) firstprivate(curr_level_l)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,counter_parts) firstprivate(curr_level_l)  if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 

--- a/src/data_structures/APR/APRAccess.hpp
+++ b/src/data_structures/APR/APRAccess.hpp
@@ -415,7 +415,9 @@ public:
             //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
             // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -465,7 +467,9 @@ public:
             int z_num_d =apr.pc_data.z_num[i];
             int y_num_d =apr.pc_data.y_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val,status,y_coord) if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -573,7 +577,9 @@ public:
             const unsigned int z_num_ds = z_num[i - 1];
             const unsigned int y_num_ds = y_num[i - 1];
 
-#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = 0; z_ < z_num_; z_++) {
 
                 for (x_ = 0; x_ < x_num_; x_++) {
@@ -610,7 +616,9 @@ public:
             const uint64_t z_num_ = z_num[i];
             const uint64_t y_num_ = y_num[i];
 
-#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = 0; z_ < z_num_; z_++) {
 
                 for (x_ = 0; x_ < x_num_; x_++) {
@@ -671,7 +679,9 @@ public:
         const unsigned int z_num_us = z_num[i + 1];
         const unsigned int y_num_us = y_num[i + 1];
 
-#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
 
             for (x_ = 0; x_ < x_num_; x_++) {
@@ -725,7 +735,9 @@ public:
 
         }
 
-#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, y_, status) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
 
             for (x_ = 0; x_ < x_num_; x_++) {
@@ -847,7 +859,9 @@ public:
             const unsigned int x_num_ = x_num[i];
             const unsigned int z_num_ = z_num[i];
             const unsigned int y_num_ = y_num[i];
-#pragma omp parallel for default(shared) private(z_, x_) reduction(+:counter_rows)if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_) reduction(+:counter_rows)if(z_num_*x_num_ > 100)
+#endif
             for (z_ = 0; z_ < z_num_; z_++) {
                 for (x_ = 0; x_ < x_num_; x_++) {
                     const size_t offset_pc_data = x_num_ * z_ + x_;
@@ -873,7 +887,9 @@ public:
 
         for (uint64_t level = apr_iterator.level_min(); level < apr_iterator.level_max(); ++level) {
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number = apr_iterator.particles_level_begin(level); particle_number <  apr_iterator.particles_level_end(level); ++particle_number) {
                 //
                 //  Parallel loop over level
@@ -934,7 +950,9 @@ public:
             counter+=(map_data.number_gaps[j]);
         }
 
-#pragma omp parallel for default(shared) schedule(static) private(j)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) schedule(static) private(j)
+#endif
         for (j = 0; j < total_number_non_empty_rows; ++j) {
 
             const uint64_t level = map_data.level[j];

--- a/src/data_structures/APR/ExtraPartCellData.hpp
+++ b/src/data_structures/APR/ExtraPartCellData.hpp
@@ -82,7 +82,9 @@ public:
             const unsigned int x_num_ = x_num[i];
             const unsigned int z_num_ = z_num[i];
 
-#pragma omp parallel for private(z_,x_)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(z_,x_)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){
@@ -112,7 +114,9 @@ public:
         const unsigned int x_num_ = x_num[level];
         const unsigned int z_num_ = z_num[level];
 
-#pragma omp parallel for private(z_,x_)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(z_,x_)
+#endif
         for(z_ = 0;z_ < z_num_;z_++){
 
             for(x_ = 0;x_ < x_num_;x_++){
@@ -152,7 +156,9 @@ public:
             data[i].resize(z_num[i]*x_num[i]);
 
             int j = 0;
-#pragma omp parallel for private(j)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(j)
+#endif
             for(j = 0;j < pc_data.data[i].size();j++){
                 data[i][j].resize(pc_data.data[i][j].size(),0);
             }
@@ -424,7 +430,9 @@ public:
             const unsigned int x_num_min_ = 0;
             const unsigned int z_num_min_ = 0;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -459,7 +467,9 @@ public:
             const unsigned int x_num_min_ = 0;
             const unsigned int z_num_min_ = 0;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -500,7 +510,9 @@ public:
             const unsigned int x_num_min_ = 0;
             const unsigned int z_num_min_ = 0;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -544,7 +556,9 @@ public:
             const unsigned int x_num_min_ = 0;
             const unsigned int z_num_min_ = 0;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -582,7 +596,9 @@ public:
             const unsigned int x_num_min_ = 0;
             const unsigned int z_num_min_ = 0;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
             for (z_ = z_num_min_; z_ < z_num_; z_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -618,7 +634,9 @@ public:
         const unsigned int x_num_min_ = 0;
         const unsigned int z_num_min_ = 0;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_) if(z_num_*x_num_ > 100)
+#endif
         for (z_ = z_num_min_; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -669,7 +687,9 @@ public:
             const unsigned int x_num_ = pdata_old.x_num[i];
             const unsigned int z_num_ = pdata_old.z_num[i];
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,node_val)  if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,node_val)  if(z_num_*x_num_ > 100)
+#endif
             for(z_ = 0;z_ < z_num_;z_++){
 
                 for(x_ = 0;x_ < x_num_;x_++){

--- a/src/data_structures/APR/ExtraParticleData.hpp
+++ b/src/data_structures/APR/ExtraParticleData.hpp
@@ -108,7 +108,9 @@ public:
         const size_t numOfElementsPerBlock = total_particles_to_iterate/aNumberOfBlocks;
 
         unsigned int blockNum;
-#pragma omp parallel for private(blockNum) schedule(static)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(blockNum) schedule(static)
+#endif
         for (blockNum = 0; blockNum < aNumberOfBlocks; ++blockNum) {
             size_t offsetBegin = particle_number_start + blockNum * numOfElementsPerBlock;
             size_t offsetEnd =  offsetBegin + numOfElementsPerBlock;
@@ -161,7 +163,9 @@ public:
         const size_t numOfElementsPerBlock = total_particles_to_iterate/aNumberOfBlocks;
 
         unsigned int blockNum;
-#pragma omp parallel for private(blockNum) schedule(static)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(blockNum) schedule(static)
+#endif
         for (blockNum = 0; blockNum < aNumberOfBlocks; ++blockNum) {
             size_t offsetBegin = particle_number_start + blockNum * numOfElementsPerBlock;
             size_t offsetEnd =  offsetBegin + numOfElementsPerBlock;
@@ -217,7 +221,9 @@ public:
         const size_t numOfElementsPerBlock = total_particles_to_iterate/aNumberOfBlocks;
 
         unsigned int blockNum;
-#pragma omp parallel for private(blockNum) schedule(static)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(blockNum) schedule(static)
+#endif
         for (blockNum = 0; blockNum < aNumberOfBlocks; ++blockNum) {
             size_t offsetBegin = particle_number_start + blockNum * numOfElementsPerBlock;
             size_t offsetEnd =  offsetBegin + numOfElementsPerBlock;
@@ -272,7 +278,9 @@ public:
         const size_t numOfElementsPerBlock = total_particles_to_iterate/aNumberOfBlocks;
 
         unsigned int blockNum;
-#pragma omp parallel for schedule(static) private(blockNum)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(blockNum)
+#endif
         for (blockNum = 0; blockNum < aNumberOfBlocks; ++blockNum) {
             size_t offsetBegin = particle_number_start + blockNum * numOfElementsPerBlock;
             size_t offsetEnd =  offsetBegin + numOfElementsPerBlock;
@@ -322,7 +330,9 @@ public:
         const size_t numOfElementsPerBlock = total_particles_to_iterate/aNumberOfBlocks;
 
         unsigned int blockNum;
-#pragma omp parallel for private(blockNum) schedule(static)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for private(blockNum) schedule(static)
+#endif
         for (blockNum = 0; blockNum < aNumberOfBlocks; ++blockNum) {
             size_t offsetBegin = particle_number_start + blockNum * numOfElementsPerBlock;
             size_t offsetEnd =  offsetBegin + numOfElementsPerBlock;

--- a/src/data_structures/Mesh/MeshData.hpp
+++ b/src/data_structures/Mesh/MeshData.hpp
@@ -153,7 +153,9 @@ public :
 
         unsigned int blockNum;
 
-        #pragma omp parallel for private(blockNum)  schedule(static)
+        #ifdef HAVE_OPENMP
+	#pragma omp parallel for private(blockNum)  schedule(static)
+#endif
         for (blockNum = 0; blockNum < aNumberOfBlocks; ++blockNum) {
             const size_t elementSize = (size_t)x_num * y_num;
             const size_t blockSize = numOfElementsPerBlock * elementSize;
@@ -518,7 +520,9 @@ void const_upsample_img(MeshData<T>& input_us,MeshData<T>& input,std::vector<uns
     
     unsigned int j, i, k;
     
-#pragma omp parallel for default(shared) private(j,i,k) firstprivate(temp_vec) if(z_num_ds_l*x_num_ds_l > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,i,k) firstprivate(temp_vec) if(z_num_ds_l*x_num_ds_l > 100)
+#endif
     for(j = 0;j < z_num_ds_l;j++){
         
         for(i = 0;i < x_num_ds_l;i++){
@@ -650,7 +654,9 @@ void down_sample_overflow_proct(MeshData<T>& test_a, MeshData<S>& test_a_ds, L1 
 
     int i, k, si_, sj_, sk_;
 
-#pragma omp parallel for default(shared) private(i,k,si_,sj_,sk_) firstprivate(temp_vec,temp_vec2)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,si_,sj_,sk_) firstprivate(temp_vec,temp_vec2)
+#endif
     for(int j = 0;j < z_num_ds; j++) {
 
 
@@ -768,7 +774,9 @@ void down_sample(MeshData<T>& test_a, MeshData<S>& test_a_ds, L1 reduce, L2 cons
 
     int i, k, si_, sj_, sk_;
 
-#pragma omp parallel for default(shared) private(i,k,si_,sj_,sk_) firstprivate(temp_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,si_,sj_,sk_) firstprivate(temp_vec)
+#endif
     for(int j = 0;j < z_num_ds; j++) {
 
 

--- a/src/io/APRWriter.hpp
+++ b/src/io/APRWriter.hpp
@@ -697,7 +697,9 @@ public:
         typev.resize(apr_iterator.total_number_particles());
 
         uint64_t particle_number = 0;
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number= 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
 
@@ -1513,7 +1515,9 @@ namespace old {
                 //For each depth there are two loops, one for SEED status particles, at depth + 1, and one for BOUNDARY and FILLER CELLS, to ensure contiguous memory access patterns.
 
                 // SEED PARTICLE STATUS LOOP (requires access to three data structures, particle access, particle data, and the part-map)
-#pragma omp parallel for default(shared) private(z_, x_, j_, node_val, status, y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, j_, node_val, status, y_coord) if(z_num_*x_num_ > 100)
+#endif
                 for (z_ = 0; z_ < z_num_; z_++) {
 
                     for (x_ = 0; x_ < x_num_; x_++) {
@@ -1563,7 +1567,9 @@ namespace old {
                 int z_num_d = apr.pc_data.z_num[i];
                 int y_num_d = apr.pc_data.y_num[i];
 
-#pragma omp parallel for default(shared) private(z_, x_, j_, node_val, status, y_coord) if(z_num_*x_num_ > 100)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_, x_, j_, node_val, status, y_coord) if(z_num_*x_num_ > 100)
+#endif
                 for (z_ = 0; z_ < z_num_; z_++) {
 
                     for (x_ = 0; x_ < x_num_; x_++) {

--- a/src/misc/APRTimer.hpp
+++ b/src/misc/APRTimer.hpp
@@ -6,8 +6,11 @@
 #define PARTPLAY_APR_TIMER_HPP
 
 #include <vector>
+#include <chrono>
 #include <iostream>
-#include "omp.h"
+#ifdef HAVE_OPENMP
+	#include "omp.h"
+#endif
 
 class APRTimer{
 //
@@ -25,8 +28,8 @@ std::vector<std::string> timing_names;
 
 int timer_count;
 
-double t1;
-double t2;
+std::chrono::system_clock::time_point t1;
+std::chrono::system_clock::time_point t2;
 
 bool verbose_flag; //turn to true if you want all the functions to write out their timings to terminal
 
@@ -41,19 +44,20 @@ APRTimer(){
 void start_timer(std::string timing_name){
     timing_names.push_back(timing_name);
 
-    t1 = omp_get_wtime();
+    t1 = std::chrono::system_clock::now();
 }
 
 
 void stop_timer(){
-    t2 = omp_get_wtime();
+    t2 = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsed_seconds = t2 - t1;
 
-    timings.push_back(t2-t1);
+    timings.push_back(elapsed_seconds.count());
 
     if (verbose_flag){
         //output to terminal the result
         std::cout <<  timing_names[timer_count] << " took "
-                  << t2-t1
+                  << elapsed_seconds.count()
                   << " seconds\n";
     }
     timer_count++;

--- a/src/numerics/APRCompress.hpp
+++ b/src/numerics/APRCompress.hpp
@@ -298,7 +298,9 @@ void APRCompress<ImageType>::predict_particles_by_level(APR<U>& apr,const unsign
 
     timer.start_timer("loop");
 
-#pragma omp parallel for schedule(dynamic) private(z_block) firstprivate(neighbour_iterator,apr_iterator,z_block_begin,z_block_end)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(dynamic) private(z_block) firstprivate(neighbour_iterator,apr_iterator,z_block_begin,z_block_end)
+#endif
     for (z_block = 0; z_block < num_z_blocks; ++z_block) {
 
         for (unsigned int z = z_block_begin[z_block]; z < z_block_end[z_block]; ++z) {

--- a/src/numerics/APRRaycaster.hpp
+++ b/src/numerics/APRRaycaster.hpp
@@ -206,7 +206,9 @@ void APRRaycaster::perform_raycast(APR<U>& apr,ExtraParticleData<S>& particle_da
 
         float y_actual,x_actual,z_actual;
 
-#pragma omp parallel for schedule(static) private(particle_number,y_actual,x_actual,z_actual) firstprivate(apr_iterator,mvp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number,y_actual,x_actual,z_actual) firstprivate(apr_iterator,mvp)
+#endif
         for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
 
@@ -254,7 +256,9 @@ void APRRaycaster::perform_raycast(APR<U>& apr,ExtraParticleData<S>& particle_da
         for (level = (level_min); level < apr.level_max(); level++) {
 
             const int step_size = pow(2, apr.level_max() - level);
-#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if (level > 8)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) schedule(guided) if (level > 8)
+#endif
             for (x_ = 0; x_ < depth_slice[level].x_num; x_++) {
                 //both z and x are explicitly accessed in the structure
 
@@ -296,8 +300,9 @@ void APRRaycaster::perform_raycast(APR<U>& apr,ExtraParticleData<S>& particle_da
     }
 
     timer.stop_timer();
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
 
-    std::cout << (timer.t2 - timer.t1)/(view_count*1.0) <<  " seconds per view" << std::endl;
+    std::cout << elapsed_seconds.count()/(view_count*1.0) <<  " seconds per view" << std::endl;
 
 
 
@@ -393,7 +398,9 @@ float APRRaycaster::perpsective_mesh_raycast(MeshData<S>& image) {
         const float step_size = 1;
         const unsigned int y_num_ = image.y_num;
 
-#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) firstprivate(mvp)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(z_,x_,j_,i,k) firstprivate(mvp)
+#endif
         for (z_ = 0; z_ < z_num_; z_++) {
             //both z and x are explicitly accessed in the structure
 
@@ -429,11 +436,12 @@ float APRRaycaster::perpsective_mesh_raycast(MeshData<S>& image) {
     }
 
     timer.stop_timer();
+    std::chrono::duration<float> elapsed_seconds = timer.t2 - timer.t1;
 
 
     debug_write(cast_views, this->name + "perspective_mesh_projection");
 
-    return (timer.t2 - timer.t1);
+    return elapsed_seconds.count();
 
 
 }

--- a/src/numerics/APRReconstruction.hpp
+++ b/src/numerics/APRReconstruction.hpp
@@ -37,7 +37,9 @@ public:
 
             const float step_size = pow(2,apr_iterator.level_max() - level);
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
             for (particle_number = apr_iterator.particles_level_begin(level); particle_number <  apr_iterator.particles_level_end(level); ++particle_number) {
                 //
                 //  Parallel loop over level
@@ -60,7 +62,9 @@ public:
                 for (int q = dim3; q < offset_max_dim3; ++q) {
 
                     for (int k = dim2; k < offset_max_dim2; ++k) {
-    #pragma omp simd
+    #ifdef HAVE_OPENMP
+	#pragma omp simd
+#endif
                         for (int i = dim1; i < offset_max_dim1; ++i) {
                             img.mesh[i + (k) * img.y_num + q * img.y_num * img.x_num] = temp_int;
                         }
@@ -85,7 +89,9 @@ public:
         APRIterator<S> apr_iterator(apr);
         uint64_t particle_number;
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
 
@@ -116,7 +122,9 @@ public:
         APRIterator<S> apr_iterator(apr);
         uint64_t particle_number;
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
             //
@@ -142,7 +150,9 @@ public:
         APRIterator<S> apr_iterator(apr);
         uint64_t particle_number;
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
         for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
             apr_iterator.set_iterator_to_particle_by_number(particle_number);
             //
@@ -189,7 +199,9 @@ public:
 
         //const unsigned int d_max = this->depth_max();
 
-#pragma omp parallel for default(shared) private(i,k,counter,temp,index,divisor,offset) firstprivate(temp_vec,offset_vec)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,counter,temp,index,divisor,offset) firstprivate(temp_vec,offset_vec)
+#endif
         for(int j = 0;j < z_num;j++){
             for(i = 0;i < x_num;i++){
 
@@ -308,8 +320,10 @@ public:
         //const unsigned int d_max = this->depth_max();
 
 
-#pragma omp parallel for default(shared) private(i,k,temp,index_modulo, previous_modulo, forward_modulo,backward_modulo,current_index, jxnumynum,offset) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(i,k,temp,index_modulo, previous_modulo, forward_modulo,backward_modulo,current_index, jxnumynum,offset) \
         firstprivate(temp_vec)
+#endif
         for(int j = 0; j < z_num; j++) {
 
             jxnumynum = j * x_num * y_num;
@@ -421,8 +435,10 @@ public:
         std::vector<T> temp_vec;
         temp_vec.resize(y_num*(2*offset_max + 2),0);
 
-#pragma omp parallel for default(shared) private(j,k,temp,index_modulo, previous_modulo, current_index,backward_modulo,forward_modulo, iynum,offset) \
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared) private(j,k,temp,index_modulo, previous_modulo, current_index,backward_modulo,forward_modulo, iynum,offset) \
         firstprivate(temp_vec)
+#endif
         for(int i = 0; i < x_num; i++) {
 
             iynum = i * y_num;

--- a/test/APRTest.cpp
+++ b/test/APRTest.cpp
@@ -321,7 +321,9 @@ bool test_apr_neighbour_access(TestData& test_data){
         }
     }
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
 
         apr_iterator.set_iterator_to_particle_by_number(particle_number);
@@ -458,7 +460,9 @@ bool test_apr_iterate(TestData& test_data){
 
     //Test parallel loop
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         apr_iterator.set_iterator_to_particle_by_number(particle_number);
 

--- a/test/Examples/Example_apr_iterate.cpp
+++ b/test/Examples/Example_apr_iterate.cpp
@@ -160,7 +160,9 @@ int main(int argc, char **argv) {
 
     timer.start_timer("APR parallel iterator loop");
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         //needed step for any parallel loop (update to the next part)
         apr_iterator.set_iterator_to_particle_by_number(particle_number);
@@ -200,7 +202,9 @@ int main(int argc, char **argv) {
     //compare to explicit loop
     timer.start_timer("Using parallel iterator loop: square the dataset");
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         //needed step for any parallel loop (update to the next part)
         apr_iterator.set_iterator_to_particle_by_number(particle_number);
@@ -278,7 +282,9 @@ int main(int argc, char **argv) {
             uint64_t  begin = apr_iterator.particles_z_begin(level,z);
             uint64_t  end = apr_iterator.particles_z_end(level,z);
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
             for (particle_number = apr_iterator.particles_z_begin(level,z);
                  particle_number < apr_iterator.particles_z_end(level,z); ++particle_number) {
                 //
@@ -310,7 +316,9 @@ int main(int argc, char **argv) {
     for (int level = apr_iterator.level_min(); level <= apr_iterator.level_max(); ++level) {
 
         int z = 0;
-#pragma omp parallel for schedule(static) private(particle_number,z) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number,z) firstprivate(apr_iterator)
+#endif
         for(z = 0; z < apr.spatial_index_z_max(level); ++z) {
 
             uint64_t  begin = apr_iterator.particles_z_begin(level,z);

--- a/test/Examples/Example_apr_neighbour_access.cpp
+++ b/test/Examples/Example_apr_neighbour_access.cpp
@@ -143,7 +143,9 @@ int main(int argc, char **argv) {
 
     timer.start_timer("APR parallel iterator neighbour loop");
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         //needed step for any parallel loop (update to the next part)
 
@@ -177,7 +179,9 @@ int main(int argc, char **argv) {
     //need to initialize the neighbour iterator with the APR you are iterating over.
 
     timer.start_timer("APR parallel iterator neighbours loop only -x face neighbours");
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         //needed step for any parallel loop (update to the next part)
 

--- a/test/Examples/Example_compute_gradient.cpp
+++ b/test/Examples/Example_compute_gradient.cpp
@@ -116,7 +116,9 @@ int main(int argc, char **argv) {
     //  Calculates an estimate of the gradient in each direciton, using an average of two one sided FD of the gradient using the average of particles for children.
     //
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator,neighbour_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         //needed step for any parallel loop (update to the next part)
 

--- a/test/Examples/Example_reconstruct_image.cpp
+++ b/test/Examples/Example_reconstruct_image.cpp
@@ -81,8 +81,9 @@ int main(int argc, char **argv) {
     apr.interp_img(recon_pc,apr.particles_intensities);
 
     timer.stop_timer();
+    std::chrono::duration<double> elapsed_seconds = timer.t2 - timer.t1;
 
-    std::cout << "PC recon " << (recon_pc.x_num*recon_pc.y_num*recon_pc.z_num)/((timer.t2 - timer.t1)*1000000.0) << " million pixels per second"  <<  std::endl;
+    std::cout << "PC recon " << (recon_pc.x_num*recon_pc.y_num*recon_pc.z_num)/(elapsed_seconds.count()*1000000.0) << " million pixels per second"  <<  std::endl;
 
     std::string output_path = options.directory + apr.name + "_pc.tif";
 
@@ -105,7 +106,9 @@ int main(int argc, char **argv) {
 
     timer.start_timer("APR parallel iterator loop");
 
-#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for schedule(static) private(particle_number) firstprivate(apr_iterator)
+#endif
     for (particle_number = 0; particle_number < apr_iterator.total_number_particles(); ++particle_number) {
         //needed step for any parallel loop (update to the next part)
         apr_iterator.set_iterator_to_particle_by_number(particle_number);
@@ -143,8 +146,9 @@ int main(int argc, char **argv) {
     apr.interp_parts_smooth(recon_smooth,apr.particles_intensities,scale_d);
 
     timer.stop_timer();
+    elapsed_seconds = timer.t2 - timer.t1;
 
-    std::cout << "Smooth recon " << (recon_smooth.x_num*recon_smooth.y_num*recon_smooth.z_num)/((timer.t2 - timer.t1)*1000000.0) << " million pixels per second"  <<  std::endl;
+    std::cout << "Smooth recon " << (recon_smooth.x_num*recon_smooth.y_num*recon_smooth.z_num)/(elapsed_seconds.count()*1000000.0) << " million pixels per second"  <<  std::endl;
 
     output_path = options.directory + apr.name + "_smooth.tif";
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -158,7 +158,9 @@ MeshData<uint16_t> generate_random_ktest_example(unsigned int size_y, unsigned i
 
     MeshData<uint16_t> test_example(size_y, size_x, size_z);
 
-#pragma omp parallel for default(shared)
+#ifdef HAVE_OPENMP
+	#pragma omp parallel for default(shared)
+#endif
     for(int i = 0; i < test_example.mesh.size(); i++){
         test_example.mesh[i] = get_random_number_k(generator, distribution, k_max);
     }


### PR DESCRIPTION
Does not require OpenMP in CMakeLists anymore, but enable it if found. Introduces some `#ifdef`s for the `HAVE_OPENMP` macro.