### PR TITLE
Minor fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - libhdf5-dev
         - libtiff5
   - os: osx
-    osx_image: xcode10.1
+    osx_image: xcode9.2
 
 install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - libhdf5-dev
         - libtiff5
   - os: osx
-    osx_image: xcode7.3
+    osx_image: xcode10.1
 
 install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/examples/Example_get_apr.cpp
+++ b/examples/Example_get_apr.cpp
@@ -91,8 +91,8 @@ int runAPR(cmdLineOptions options) {
         std::cout << "Writing the APR to hdf5..." << std::endl;
 
         //feel free to change
-        unsigned int blosc_comp_type = 6; //Lizard Codec
-        unsigned int blosc_comp_level = 9;
+        unsigned int blosc_comp_type = BLOSC_ZSTD; //Lizard Codec
+        unsigned int blosc_comp_level = 4;
         unsigned int blosc_shuffle = 1;
 
         apr.apr_compress.set_compression_type(options.compress_type);

--- a/src/data_structures/APR/APRIterator.hpp
+++ b/src/data_structures/APR/APRIterator.hpp
@@ -116,6 +116,8 @@ inline uint64_t APRIterator::set_new_lzx(const uint16_t level,const uint16_t z,c
 
                 return this->current_particle_cell.global_index;
             } else {
+                this->end_index = 0;
+                current_particle_cell.y = UINT16_MAX;
                 return UINT64_MAX;
             }
 
@@ -139,6 +141,8 @@ inline uint64_t APRIterator::set_new_lzx(const uint16_t level,const uint16_t z,c
 
                 return this->current_particle_cell.global_index;
             } else {
+                this->end_index = 0;
+                current_particle_cell.y = UINT16_MAX;
                 return UINT64_MAX;
             }
 

--- a/src/data_structures/APR/APRTree.hpp
+++ b/src/data_structures/APR/APRTree.hpp
@@ -235,12 +235,12 @@ public:
 
                                 if (parentIterator.y() == (parentIterator.spatial_index_y_max(level - 1) - 1)) {
                                     tree_data[parentIterator] =
-                                            scale_factor_yxz * apr.particles_intensities[apr_iterator] / 8.0f +
+                                            scale_factor_yxz * particle_data[apr_iterator] / 8.0f +
                                             tree_data[parentIterator];
                                 } else {
 
                                     tree_data[parentIterator] =
-                                            scale_factor_xz * apr.particles_intensities[apr_iterator] / 8.0f +
+                                            scale_factor_xz * particle_data[apr_iterator] / 8.0f +
                                             tree_data[parentIterator];
                                 }
 

--- a/src/data_structures/APR/APRTreeIterator.hpp
+++ b/src/data_structures/APR/APRTreeIterator.hpp
@@ -312,6 +312,8 @@ uint64_t APRTreeIterator::set_new_lzx(const uint16_t level,const uint16_t z,cons
 
             return this->current_particle_cell.global_index;
         } else {
+            this->end_index = 0;
+            current_particle_cell.y = UINT16_MAX;
             return UINT64_MAX;
         }
 
@@ -333,6 +335,8 @@ uint64_t APRTreeIterator::set_new_lzx(const uint16_t level,const uint16_t z,cons
 
             return this->current_particle_cell.global_index;
         } else {
+            this->end_index = 0;
+            current_particle_cell.y = UINT16_MAX;
             return UINT64_MAX;
         }
 


### PR DESCRIPTION
* The tree down sample was directly taking the particles from the APR, rather then the input ExtraParticleData.
* Was a setting used for BLOSC in the get apr example that could lead to the  run length coding being turned completely off leading to no compression of particle data.