### PR TITLE
Update the OSX instructions which had an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cmake ..
 make
 ```
 
-This will create the `libapr.so` library in the `build` directory, as well as all of the examples.
+This will create the `libapr.dylib` library in the `build` directory, as well as all of the examples.
 
 In case you want to use the homebrew-installed clang (OpenMP support), modify the call to `cmake` above to
 


### PR DESCRIPTION
OSX instructions said a .so would be created instead of a dylib.