### PR TITLE
The use of collapse(2) seems to place tighter constraints on the test…

### DIFF
--- a/src/numerics/APRReconstruction.hpp
+++ b/src/numerics/APRReconstruction.hpp
@@ -85,7 +85,7 @@ public:
             const int step_size = (int) pow(2, max_level - level);
 
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(img, level, parts) private(z, x, temp_int) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(none) shared(img, level, parts, step_size) private(z, x, temp_int) firstprivate(apr_iterator) collapse(2)
 #endif
             for (z = 0; z < apr_iterator.z_num(level); z++) {
                 for (x = 0; x < apr_iterator.x_num(level); ++x) {
@@ -115,7 +115,7 @@ public:
 
         // loop over max_level
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(img, parts) private(z, x) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(none) shared(img, parts, max_level) private(z, x) firstprivate(apr_iterator) collapse(2)
 #endif
         for (z = 0; z < apr_iterator.z_num(max_level); z++) {
             for (x = 0; x < apr_iterator.x_num(max_level); ++x) {
@@ -596,7 +596,7 @@ public:
             const int step_size = pow(2, max_level - level);
 
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(level_val, level, img) private(z, x) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(none) shared(level_val, level, img, step_size) private(z, x) firstprivate(apr_iterator) collapse(2)
 #endif
             for (z = 0; z < apr_iterator.z_num(level); z++) {
                 for (x = 0; x < apr_iterator.x_num(level); ++x) {
@@ -625,7 +625,7 @@ public:
         // loop over max_level
         level_val = max_level;
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(level_val, img) private(z, x) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(none) shared(level_val, img, max_level) private(z, x) firstprivate(apr_iterator) collapse(2)
 #endif
         for (z = 0; z < apr_iterator.z_num(max_level); z++) {
             for (x = 0; x < apr_iterator.x_num(max_level); ++x) {

--- a/src/numerics/APRReconstruction.hpp
+++ b/src/numerics/APRReconstruction.hpp
@@ -85,7 +85,7 @@ public:
             const int step_size = (int) pow(2, max_level - level);
 
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(img, level, parts, step_size) private(z, x, temp_int) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(shared) private(z, x, temp_int) firstprivate(apr_iterator) collapse(2)
 #endif
             for (z = 0; z < apr_iterator.z_num(level); z++) {
                 for (x = 0; x < apr_iterator.x_num(level); ++x) {
@@ -115,7 +115,7 @@ public:
 
         // loop over max_level
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(img, parts, max_level) private(z, x) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(shared) private(z, x) firstprivate(apr_iterator) collapse(2)
 #endif
         for (z = 0; z < apr_iterator.z_num(max_level); z++) {
             for (x = 0; x < apr_iterator.x_num(max_level); ++x) {
@@ -587,16 +587,15 @@ public:
 
         auto apr_iterator = apr.iterator();
         const int max_level = apr.level_max();
-        U level_val;
         int z, x;
 
         // loop over levels up to max_level-1
         for (int level = apr_iterator.level_min(); level < apr_iterator.level_max(); ++level) {
-            level_val = level;
-            const int step_size = pow(2, max_level - level);
+            const U level_val = level;
+            const int step_size = (int)pow(2, max_level - level);
 
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(level_val, level, img, step_size) private(z, x) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(shared) private(z, x) firstprivate(apr_iterator) collapse(2)
 #endif
             for (z = 0; z < apr_iterator.z_num(level); z++) {
                 for (x = 0; x < apr_iterator.x_num(level); ++x) {
@@ -623,9 +622,9 @@ public:
         }
 
         // loop over max_level
-        level_val = max_level;
+        const U level_val = max_level;
 #ifdef HAVE_OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(level_val, img, max_level) private(z, x) firstprivate(apr_iterator) collapse(2)
+#pragma omp parallel for schedule(dynamic) default(shared) private(z, x) firstprivate(apr_iterator) collapse(2)
 #endif
         for (z = 0; z < apr_iterator.z_num(max_level); z++) {
             for (x = 0; x < apr_iterator.x_num(max_level); ++x) {


### PR DESCRIPTION
…ing of shared variables, and requiring them to be explicitly declared shared