### PR TITLE
Tmp install windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
         - libtiff5
   - os: osx
     osx_image: xcode11.4
+  - os: windows
+    language: cpp
+
 
 install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
@@ -28,8 +31,12 @@ install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export COMPILER=clang++-3.6; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=clang++-3.6; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CC=clang-3.6; fi
+- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then travis_wait 10 choco install visualstudio2019buildtools --params "--add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.Windows10SDK.19041	--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.UWP.VC.BuildTools"; fi
 - git submodule init
 - git submodule update
 
 script:
-- sh ./cmake-build.sh
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh ./cmake-build.sh; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sh ./cmake-build.sh; fi
+- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then travis_wait 40 sh ./cmake-build_windows.sh; fi
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ set(LIBRARY_NAME APR)
 include_directories(src)
 
 set(SOURCE_FILES src/io/blosc_filter.c src/io/hdf5functions_blosc.cpp)
-set(SOURCE_FILES_RAYCAST src/vis/Camera.cpp src/vis/Object.cpp src/vis/RaytracedObject.cpp src/numerics/APRRaycaster.cpp)
+set(SOURCE_FILES_RAYCAST src/vis/Camera.cpp src/vis/Object.cpp src/vis/RaytracedObject.cpp)
 
 
 add_library(aprObjLib OBJECT ${SOURCE_FILES} ${SOURCE_FILES_RAYCAST})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,8 +198,7 @@ set(LIBRARY_NAME APR)
 include_directories(src)
 
 set(SOURCE_FILES src/io/blosc_filter.c src/io/hdf5functions_blosc.cpp)
-set(SOURCE_FILES_RAYCAST src/vis/Camera.cpp src/vis/Object.cpp src/vis/RaytracedObject.cpp)
-
+set(SOURCE_FILES_RAYCAST src/vis/Camera.cpp src/vis/Object.cpp src/vis/RaytracedObject.cpp src/vis/RaycastUtils.cpp)
 
 add_library(aprObjLib OBJECT ${SOURCE_FILES} ${SOURCE_FILES_RAYCAST})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,23 @@
 ###############################################################################
 # APR - Adaptive Particle Representation
 ###############################################################################
-cmake_minimum_required(VERSION 3.9)
-project(LibAPR DESCRIPTION "Adaptive Particle Representation library")
+cmake_minimum_required(VERSION 3.10)
+project(APR DESCRIPTION "Adaptive Particle Representation library")
+
+message(STATUS "CMAKE VERSION ${CMAKE_VERSION}")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # APR build options:
 option(APR_INSTALL "Install APR library" OFF)
-option(APR_BUILD_SHARED_LIB "Builds shared library" ON)
-option(APR_BUILD_STATIC_LIB "Builds static library" OFF)
+option(APR_BUILD_SHARED_LIB "Builds shared library" OFF)
+option(APR_BUILD_STATIC_LIB "Builds static library" ON)
 option(APR_BUILD_EXAMPLES "Build APR examples" OFF)
 option(APR_USE_LIBTIFF "Use LibTIFF" ON)
 option(APR_TESTS "Build APR tests" OFF)
-option(APR_PREFER_EXTERNAL_GTEST "When found, use the installed GTEST libs instead of included sources" OFF)
-option(APR_PREFER_EXTERNAL_BLOSC "When found, use the installed BLOSC libs instead of included sources" OFF)
+option(APR_PREFER_EXTERNAL_GTEST "When found, use the installed GTEST libs instead of included sources" ON)
+option(APR_PREFER_EXTERNAL_BLOSC "When found, use the installed BLOSC libs instead of included sources" ON)
 option(APR_USE_CUDA "should APR use CUDA? (experimental - under development)" OFF)
 option(APR_USE_OPENMP "should APR use OpenMP?" ON)
 option(APR_BENCHMARK "add benchmarking code" OFF)
@@ -77,7 +79,6 @@ if(APR_DENOISE)
 
 endif()
 
-
 if(APR_USE_LIBTIFF)
     find_package(TIFF)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_LIBTIFF")
@@ -86,17 +87,22 @@ endif()
 
 # Handle OpenMP
 find_package(OpenMP)
+
 if(NOT OPENMP_FOUND OR NOT APR_USE_OPENMP)
     message(WARNING "OpenMP support not found or disabled with current compiler. While APR can compile like this, performance might not be optimal. Please see README.md for instructions.")
+    set(OPENMP_LINK "")
 else()
+    set(OPENMP_LINK "OpenMP::OpenMP_CXX")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_OPENMP ${OpenMP_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_OPENMP ${OpenMP_CXX_FLAGS}")
 endif()
+
 include_directories(${HDF5_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${TIFF_INCLUDE_DIR})
 
 if(APR_PREFER_EXTERNAL_BLOSC)
     find_package(BLOSC)
 endif()
+
 if(BLOSC_FOUND)
     message(STATUS "APR: blosc found, using external blosc")
     include_directories(${BLOSC_INCLUDE_DIR})
@@ -132,18 +138,49 @@ include_directories(external/glm)
 # If you ever want to compile with Intel's icc (or any other compiler) provide
 # compiler names/paths in cmake command like this:
 # CC="icc" CXX="icc" CXXFLAGS="-O3" cmake -DAPR_TESTS=1
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 ")
-if(CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_CXX_FLAGS_RELEASE "-O4 -ffast-math")
-    set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g  -Wall -pedantic")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Bdynamic")
-    if(NOT WIN32)
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ldl -lz")
+
+if(WIN32)
+
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWIN_COMPILE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN_COMPILE")
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+        message(STATUS "Compiling on windows with CLANG!")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fcxx-exceptions")
+
+        set(CMAKE_CXX_FLAGS_DEBUG "/MD /Z7")
+        set(CMAKE_CXX_FLAGS_RELEASE "/MD /EHsc /std:c++17 /arch:AVX2 -Xclang -O3 /nologo /fp:fast") #-flto=thin -march=native /O2 /Ob2
+
     endif()
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math")
-    set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g  -Wall -pedantic")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lz")
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        message(STATUS "Compiling on windows with MSVC!")
+
+        set(CMAKE_CXX_FLAGS_RELEASE "/MD /EHsc /std:c++17 /arch:AVX2 /O2 /Ob2 /nologo /fp:fast")
+        set(CMAKE_CXX_FLAGS_DEBUG "/MD /Z7")
+
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWIN_VS")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN_VS")
+
+    endif()
+
+
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 ")
+
+    if(CMAKE_COMPILER_IS_GNUCC)
+        set(CMAKE_CXX_FLAGS_RELEASE "-O4 -ffast-math")
+        set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g  -Wall -pedantic")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Bdynamic")
+        if(NOT WIN32)
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ldl -lz")
+        endif()
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math")
+        set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g  -Wall -pedantic")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lz")
+    endif()
 endif()
 
 if (APR_BENCHMARK)
@@ -156,12 +193,13 @@ endif()
 # Generate APR library
 ###############################################################################
 
-set(LIBRARY_NAME apr)
+set(LIBRARY_NAME APR)
 
 include_directories(src)
 
 set(SOURCE_FILES src/io/blosc_filter.c src/io/hdf5functions_blosc.cpp)
 set(SOURCE_FILES_RAYCAST src/vis/Camera.cpp src/vis/Object.cpp src/vis/RaytracedObject.cpp src/numerics/APRRaycaster.cpp)
+
 
 add_library(aprObjLib OBJECT ${SOURCE_FILES} ${SOURCE_FILES_RAYCAST})
 
@@ -207,9 +245,10 @@ if(APR_BUILD_STATIC_LIB)
     # generate fat static library by adding dependencies
     if(NOT BLOSC_FOUND)
         include(cmake/AddStaticLibs.cmake)
-        addStaticLibs(${STATIC_TARGET_NAME} blosc_static)
+        addStaticLibs(${STATIC_TARGET_NAME} blosc_static) #this is not working currently for clang-cl please use external.
+    else()
+        target_link_libraries(${STATIC_TARGET_NAME} PRIVATE ${BLOSC_LIBRARIES}  ${ZLIB_LIBRARIES} )
     endif()
-
 
 endif()
 

--- a/INSTALL_INSTRUCTIONS.md
+++ b/INSTALL_INSTRUCTIONS.md
@@ -7,37 +7,45 @@ APR_BUILD_SHARED_LIB=OFF
 APR_INSTALL=ON
 (all other configuration possibilities are now in the top of CMakeLists.txt file)
 
-so full command line would look like:
+## OSX / UNIX Installation
+
+so full command line would look like: (-DCMAKE_INSTALL_PREFIX=/tmp/APR can be used for a non-default location)
 
 ```
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/tmp/APR -DAPR_INSTALL=ON -DAPR_BUILD_STATIC_LIB=ON -DAPR_BUILD_SHARED_LIB=OFF ..
+cmake -DAPR_INSTALL=ON -DAPR_BUILD_STATIC_LIB=ON -DAPR_BUILD_SHARED_LIB=OFF ..
 make
 make install
 ```
 
-To use APR the minimalistic CMakeLists.txt file would look like:
+You may need file-permissions (sudo for the install)
 
-```
-cmake_minimum_required(VERSION 3.2)
-project(myAprProject)
-set(CMAKE_CXX_STANDARD 14)
+## Windows Installation Clang
 
-#external libraries needed for APR
-find_package(HDF5 REQUIRED)
-find_package(TIFF REQUIRED)
-include_directories(${HDF5_INCLUDE_DIRS} ${TIFF_INCLUDE_DIR} )
+``
+cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_TOOLCHAIN_FILE="PATH_TO_VCPKG\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -T ClangCL -DAPR_BUILD_STATIC_LIB=ON -DAPR_BUILD_SHARED_LIB=OFF -DAPR_INSTALL=ON ..
+cmake --build . --config Release
+``
 
-find_package(APR REQUIRED)
+Need to be in a console running as administrator. 
 
-add_executable(HelloAPR helloWorld.cpp)
-target_link_libraries(HelloAPR  ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} apr::staticLib)
-```
+``
+cmake --install .
+``
 
-if shared version is preferred then apr::sharedLib should be used (and of course APR_BUILD_SHARED_LIB=ON during lib build step).
+## Minimal example CMAKE
 
-NOTICE: if APR is isntalled in not standard directory then some hint for cmake must be provided by adding install dir to CMAKE_PREFIX_PATH like for above example:
+To use APR the minimalistic CMakeLists.txt file can be found here: https://github.com/AdaptiveParticles/APR_cpp_project_example
+
+##
+
+APR::staticLib (Note, tested across Windows, Linux, and Mac)
+APR::sharedLib (Note, not tested)
+
+If shared version is preferred then APR::sharedLib should be used (and of course APR_BUILD_SHARED_LIB=ON during lib build step).
+
+NOTICE: if APR is installed in not standard directory then some hint for cmake must be provided by adding install dir to CMAKE_PREFIX_PATH like for above example:
 
 ```
 export CMAKE_PREFIX_PATH=/tmp/APR:$CMAKE_PREFIX_PATH

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ cmake -DAPR_USE_OPENMP=OFF ..
 
 | Option | Description | Default value |
 |:--|:--|:--|
-| APR_BUILD_SHARED_LIB | Build shared library | ON |
-| APR_BUILD_STATIC_LIB | Build static library | OFF |
+| APR_BUILD_SHARED_LIB | Build shared library | OFF |
+| APR_BUILD_STATIC_LIB | Build static library | ON |
 | APR_BUILD_EXAMPLES | Build executable examples | OFF |
 | APR_TESTS | Build unit tests | OFF |
 | APR_BENCHMARK | Build executable performance benchmarks | OFF |
 | APR_USE_LIBTIFF | Enable LibTIFF (Required for tests and examples) | ON |
-| APR_PREFER_EXTERNAL_GTEST | Use installed gtest instead of included sources | OFF |
-| APR_PREFER_EXTERNAL_BLOSC | Use installed blosc instead of included sources | OFF |
+| APR_PREFER_EXTERNAL_GTEST | Use installed gtest instead of included sources | ON |
+| APR_PREFER_EXTERNAL_BLOSC | Use installed blosc instead of included sources | ON |
 | APR_USE_OPENMP | Enable multithreading via OpenMP | ON |
 | APR_USE_CUDA | Enable CUDA (Under development - APR conversion pipeline is currently not working with CUDA enabled) | OFF |
 
@@ -121,32 +121,54 @@ CC="/usr/local/opt/llvm/bin/clang" CXX="/usr/local/opt/llvm/bin/clang++" LDFLAGS
 
 ### Building on Windows
 
-__The simplest way to utilise the library from Windows 10 is through using the Windows Subsystem for Linux; see: https://docs.microsoft.com/en-us/windows/wsl/install-win10 then follow linux instructions.__
+On windows there are two working strategies we have tested. Either cheating and using WSL2 and linux above, or utilising a recent version clang-cl or clang directly as included in MSVC 2019 >16.8.6. Note for earlier versions OpenMP support did not work.
 
-__Compilation only works with mingw64/clang or the Intel C++ Compiler, with Intel C++ being the recommended way__
+The easiest way to set up your windows environment we have found is using chocolatey + vcpkg. 
 
-The below instructions for VS can be attempted; however they have not been reproduced.
+Chocolatey Install:
 
-You need to have Visual Studio 2017 installed, with [the community edition](https://www.visualstudio.com/downloads/) being sufficient. LibAPR does not compile correctly with the default Visual Studio compiler, so you also need to have the [Intel C++ Compiler, 18.0 or higher](https://software.intel.com/en-us/c-compilers) installed. [`cmake`](https://cmake.org/download/) is also a requirement.
+First install chocolatey using powershell: https://chocolatey.org/install
 
-Furthermore, you need to have HDF5 installed (binary distribution download at [The HDF Group](http://hdfgroup.org) and LibTIFF (source download from [SimpleSystems](http://www.simplesystems.org/libtiff/). LibTIFF needs to be compiled via `cmake`. LibTIFF's install target will then install the library into `C:\Program Files\tiff`.
+Open an admin powershell (for chocolatey steps)
 
-In the directory of the cloned repository, run:
+If not installed, install git and cmake:
+```
+choco install -y git 
+choco install -y cmake.portable
+```
+install the required visual studio compiler tools and clang: (Note you can also do this via downloading 2019 community and selecting the correct packages)
+```
+choco install visualstudio2019buildtools --params "--add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.Windows10SDK.19041	--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.UWP.VC.BuildTools"
+```
+Now install your dependencies using vcpkg, in an install directory (VCPKG_PATH) of your choice do the following:
+```
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+./bootstrap-vcpkg.bat
+./vcpkg.exe install blosc:x64-windows gtest:x64-windows tiff:x64-windows hdf5:x64-windows szip:x64-windows
+```
+Now navigate to your cloned LibAPR directory (git clone --recursive https://github.com/AdaptiveParticles/LibAPR.git) and use vcpkg to install the required dependencies. You should have all dependencies set up to be able to build the library with clang-cl -A x64 -T ClangCL and to search for dependencies from vcpkg at your vcpkg install location: -DCMAKE_TOOLCHAIN_FILE="VCPKG_PATH/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows .
 
+Now for example to build the tests and examples (Please note you will need to update below with your own VCPKG_PATH from the steps above.
 ```
 mkdir build
 cd build
-cmake -G "Visual Studio 15 2017 Win64" -DTIFF_INCLUDE_DIR="C:/Program Files/tiff/include" -DTIFF_LIBRARY="C:/Program Files/tiff/lib/tiff.lib " -DHDF5_ROOT="C:/Program Files/HDF_Group/HDF5/1.8.17"  -T "Intel C++ Compiler 18.0" ..
-cmake --build . --config Debug
+
+Cmake -A x64 -DCMAKE_TOOLCHAIN_FILE="VCPKG_PATH/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -T ClangCL -DAPR_BUILD_EXAMPLES=ON -DAPR_TESTS=ON ..
+cmake --build . --config Release
 ```
 
-This will set the appropriate hints for Visual Studio to find both LibTIFF and HDF5. This will create the `apr.dll` library in the `build/Debug` directory. If you need a `Release` build, run `cmake --build . --config Release` from the `build` directory.
+The above examples is also used in CI and can be executed in the cmake-build_windows.sh
 
 ### Docker build
 
 We provide a working Dockerfile that installs the library within the image in a separate [repository](https://github.com/MSusik/libaprdocker).
 
 Note: not recently tested.
+
+## Install instructions 
+
+Please see: INSTALL_INSTRUCTIONS.md and https://github.com/AdaptiveParticles/APR_cpp_project_example for a minimal project using the APR.
 
 ## Examples and Documentation
 
@@ -182,7 +204,7 @@ on the command line in your build folder. Please let us know by creating an issu
 
 ## Java wrappers
 
-Basic Java wrappers can be found at [LibAPR-java-wrapper](https://github.com/krzysg/LibAPR-java-wrapper)
+Basic Java wrappers can be found at [LibAPR-java-wrapper](https://github.com/krzysg/LibAPR-java-wrapper) Not compatable with recent releases.
 
 ## Coming soon
 

--- a/benchmarks/APRBenchHelper.hpp
+++ b/benchmarks/APRBenchHelper.hpp
@@ -390,14 +390,15 @@ public:
 
                             for (int y_tile = 0; y_tile < tile_dims[0]; ++y_tile) {
 
-                                int y_offset = (y_tile * org_dims_y) / apr_tiled.aprInfo.level_size[new_level];
+                                uint16_t y_offset = (y_tile * org_dims_y) / apr_tiled.aprInfo.level_size[new_level];
 
                                 std::copy(lin_a_input.y_vec.begin() + begin ,lin_a_input.y_vec.begin() + end,
                                         lin_a_output.y_vec.begin() + begin_new + y_tile*total);
 
-                                transform(lin_a_output.y_vec.begin() + begin_new + y_tile*total, lin_a_output.y_vec.begin() + begin_new + (y_tile+1)*total
-                                        , lin_a_output.y_vec.begin() + begin_new + y_tile*total,
-                                          bind2nd(std::plus<uint16_t>(), y_offset));
+                                std::transform(lin_a_output.y_vec.begin() + begin_new + y_tile*total,
+                                               lin_a_output.y_vec.begin() + begin_new + (y_tile+1)*total,
+                                               lin_a_output.y_vec.begin() + begin_new + y_tile*total,
+                                               [y_offset](uint16_t a){return a + y_offset;});
                                 //add constant
 
                                 std::copy(parts.data.begin() + begin ,parts.data.begin() + end,

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(buildTarget TARGET SRC)
     add_executable(${TARGET} ${SRC})
-    target_link_libraries(${TARGET} ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${GTEST_LIBRARIES} ${APR_BUILD_LIBRARY})
+    target_link_libraries(${TARGET} ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${GTEST_LIBRARIES} ${APR_BUILD_LIBRARY} Threads::Threads ${OPENMP_LINK})
 endmacro(buildTarget)
 
 ## Performance Benchmark Tests

--- a/cmake-build_windows.sh
+++ b/cmake-build_windows.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -x
+mkdir build
+cd build
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+./bootstrap-vcpkg.bat
+./vcpkg.exe install blosc:x64-windows gtest:x64-windows tiff:x64-windows hdf5:x64-windows szip:x64-windows
+cd ..
+
+cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -T ClangCL -DAPR_BUILD_EXAMPLES=ON -DAPR_BUILD_STATIC_LIB=ON -DAPR_BUILD_SHARED_LIB=OFF -DAPR_TESTS=ON ..
+cmake --build . --config Release
+
+CTEST_OUTPUT_ON_FAILURE=1 ctest -V

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(buildTarget TARGET)
     add_executable(${TARGET} ${TARGET}.cpp)
-    target_link_libraries(${TARGET} ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${APR_BUILD_LIBRARY} Threads::Threads)
+    target_link_libraries(${TARGET} ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${APR_BUILD_LIBRARY} Threads::Threads ${OPENMP_LINK})
 endmacro(buildTarget)
 
 buildTarget(Example_get_apr)

--- a/examples/Example_ray_cast.h
+++ b/examples/Example_ray_cast.h
@@ -1,7 +1,7 @@
 #ifndef LIBAPR_EXAMPLE_RAY_CAST_H
 #define LIBAPR_EXAMPLE_RAY_CAST_H
 
-#include "numerics/APRRaycaster.hpp"
+#include "numerics/APRRaycaster.cpp"
 #include "data_structures/APR/APR.hpp"
 
 struct cmdLineOptions{

--- a/examples/Example_ray_cast.h
+++ b/examples/Example_ray_cast.h
@@ -1,7 +1,7 @@
 #ifndef LIBAPR_EXAMPLE_RAY_CAST_H
 #define LIBAPR_EXAMPLE_RAY_CAST_H
 
-#include "numerics/APRRaycaster.cpp"
+#include "numerics/APRRaycaster.hpp"
 #include "data_structures/APR/APR.hpp"
 
 struct cmdLineOptions{

--- a/src/algorithm/ComputeGradient.hpp
+++ b/src/algorithm/ComputeGradient.hpp
@@ -797,12 +797,13 @@ void ComputeGradient::calc_inv_bspline_y(PixelData<T>& input){
     for (int64_t j = 0; j < z_num; ++j) {
         for (int64_t i = 0;i < x_num; ++i) {
 
+            const int64_t idx = j * x_num * y_num + i * y_num;
+
 #ifdef HAVE_OPENMP
 #pragma omp simd
 #endif
             for (int64_t k = 0; k < y_num; ++k) {
-                int64_t idx = j * x_num * y_num + i * y_num + k;
-                temp_vec[k] = input.mesh[idx];
+                temp_vec[k] = input.mesh[idx+k];
             }
 
             //LHS boundary condition
@@ -852,14 +853,16 @@ void ComputeGradient::calc_inv_bspline_z(PixelData<T>& input){
         }
 
         for (int64_t j = 0; j < z_num - 1; ++j) {
-            int64_t jxnumynum = j * xnumynum;
+            const int64_t jxnumynum = j * xnumynum;
+
+            const int64_t idx = jxnumynum + xnumynum + iynum;
 
             //initialize the loop
             #ifdef HAVE_OPENMP
 	        #pragma omp simd
             #endif
             for (int64_t k = 0; k < (y_num); ++k) {
-                temp_vec[k].temp_3 = input.mesh[jxnumynum + xnumynum + iynum + k]; // (j+1)th column in z dir
+                temp_vec[k].temp_3 = input.mesh[idx + k]; // (j+1)th column in z dir
             }
 
             #ifdef HAVE_OPENMP
@@ -909,7 +912,8 @@ void ComputeGradient::calc_inv_bspline_x(PixelData<T>& input) {
 	#pragma omp parallel for default(shared) firstprivate(temp_vec)
     #endif
     for(int64_t j = 0; j < z_num; ++j) {
-        int64_t jxnumynum = j * xnumynum;
+        const int64_t jxnumynum = j * xnumynum;
+
 
         //initialize the loop
         for (int64_t k = y_num - 1; k >= 0; --k) {
@@ -919,14 +923,16 @@ void ComputeGradient::calc_inv_bspline_x(PixelData<T>& input) {
 
         //LHS boundary condition is accounted for with this initialization
         for (int64_t i = 0; i < x_num-1; ++i) {
-            int64_t iynum = i * y_num;
+            const int64_t iynum = i * y_num;
+
+            const int64_t idx = jxnumynum + iynum + y_num;
 
             //initialize the loop
             #ifdef HAVE_OPENMP
 	        #pragma omp simd
             #endif
             for (int64_t k = 0; k < y_num; ++k) {
-                temp_vec[k].temp_3 = input.mesh[jxnumynum + iynum + y_num + k]; // get (i+1)th column
+                temp_vec[k].temp_3 = input.mesh[idx + k]; // get (i+1)th column
             }
 
             #ifdef HAVE_OPENMP

--- a/src/algorithm/LocalParticleCellSet.hpp
+++ b/src/algorithm/LocalParticleCellSet.hpp
@@ -5,7 +5,7 @@
 #ifndef PARTPLAY_LOCAL_PARTICLE_SET_HPP
 #define PARTPLAY_LOCAL_PARTICLE_SET_HPP
 
-#ifdef _MSC_VER
+#ifdef WIN_VS
 #include <intrin.h>
 
 // from https://github.com/llvm-mirror/libcxx/blob/9dcbb46826fd4d29b1485f25e8986d36019a6dca/include/support/win32/support.h#L106-L182

--- a/src/io/hdf5functions_blosc.h
+++ b/src/io/hdf5functions_blosc.h
@@ -22,28 +22,35 @@ extern "C" {
 #include <fstream>
 
 
-void hdf5_register_blosc();
-hid_t hdf5_create_file_blosc(std::string file_name);
-void hdf5_load_data_blosc(hid_t obj_id, void* buff, const char* data_name);
-void hdf5_load_data_blosc(hid_t obj_id, hid_t dataType, void* buff, const char* data_name);
-void hdf5_write_attribute_blosc(hid_t obj_id,hid_t type_id,const char* attr_name,hsize_t rank,hsize_t* dims, const void * const data );
-void hdf5_write_data_blosc(hid_t obj_id,hid_t type_id,const char* ds_name,hsize_t rank,hsize_t* dims, void* data ,unsigned int comp_type,unsigned int comp_level,unsigned int shuffle);
-void hdf5_write_data_standard(hid_t obj_id,hid_t type_id,const char* ds_name,hsize_t rank,hsize_t* dims, void* data );
-void write_main_paraview_xdmf_xml(const std::string &aDestinationDir,const std::string &aHdf5FileName, const std::string &aParaviewFileName, uint64_t aNumOfParticles);
-void hdf5_load_data_blosc_partial(hid_t obj_id, void* buff, const char* data_name,uint64_t number_of_elements_read,uint64_t number_of_elements_total);
-void write_main_paraview_xdmf_xml_time(const std::string &aDestinationDir,const std::string &aHdf5FileName, const std::string &aParaviewFileName, std::vector<uint64_t> aNumOfParticles);
+//extern "C"
+#ifdef WIN_COMPILE
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
 
-void hdf5_write_data_blosc_create(hid_t obj_id, hid_t type_id, const char *ds_name, hsize_t rank, hsize_t *dims, void *data ,unsigned int comp_type,unsigned int comp_level,unsigned int shuffle);
-uint64_t hdf5_write_data_blosc_append(hid_t obj_id, hid_t type_id, const char *ds_name, void *data,hsize_t* num_2_add);
-void hdf5_write_data_blosc_partial(hid_t obj_id, void* buff, const char* data_name,uint64_t elements_start,uint64_t elements_end);
+LIBRARY_API void hdf5_register_blosc();
+LIBRARY_API hid_t hdf5_create_file_blosc(std::string file_name);
+LIBRARY_API void hdf5_load_data_blosc(hid_t obj_id, void* buff, const char* data_name);
+LIBRARY_API void hdf5_load_data_blosc(hid_t obj_id, hid_t dataType, void* buff, const char* data_name);
+LIBRARY_API void hdf5_write_attribute_blosc(hid_t obj_id,hid_t type_id,const char* attr_name,hsize_t rank,hsize_t* dims, const void * const data );
+LIBRARY_API void hdf5_write_data_blosc(hid_t obj_id,hid_t type_id,const char* ds_name,hsize_t rank,hsize_t* dims, void* data ,unsigned int comp_type,unsigned int comp_level,unsigned int shuffle);
+LIBRARY_API void hdf5_write_data_standard(hid_t obj_id,hid_t type_id,const char* ds_name,hsize_t rank,hsize_t* dims, void* data );
+LIBRARY_API void write_main_paraview_xdmf_xml(const std::string &aDestinationDir,const std::string &aHdf5FileName, const std::string &aParaviewFileName, uint64_t aNumOfParticles);
+LIBRARY_API void hdf5_load_data_blosc_partial(hid_t obj_id, void* buff, const char* data_name,uint64_t number_of_elements_read,uint64_t number_of_elements_total);
+LIBRARY_API void write_main_paraview_xdmf_xml_time(const std::string &aDestinationDir,const std::string &aHdf5FileName, const std::string &aParaviewFileName, std::vector<uint64_t> aNumOfParticles);
 
-void hdf5_create_dataset_blosc(hid_t obj_id, hid_t type_id, const char *ds_name, hsize_t rank, hsize_t *dims,unsigned int comp_type,unsigned int comp_level,unsigned int shuffle);
+LIBRARY_API void hdf5_write_data_blosc_create(hid_t obj_id, hid_t type_id, const char *ds_name, hsize_t rank, hsize_t *dims, void *data ,unsigned int comp_type,unsigned int comp_level,unsigned int shuffle);
+LIBRARY_API uint64_t hdf5_write_data_blosc_append(hid_t obj_id, hid_t type_id, const char *ds_name, void *data,hsize_t* num_2_add);
+LIBRARY_API void hdf5_write_data_blosc_partial(hid_t obj_id, void* buff, const char* data_name,uint64_t elements_start,uint64_t elements_end);
 
-bool attribute_exists(hid_t obj_id,const char* attr_name);
+LIBRARY_API void hdf5_create_dataset_blosc(hid_t obj_id, hid_t type_id, const char *ds_name, hsize_t rank, hsize_t *dims,unsigned int comp_type,unsigned int comp_level,unsigned int shuffle);
 
-bool group_exists(hid_t fileId,const char * attr_name);
+LIBRARY_API bool attribute_exists(hid_t obj_id,const char* attr_name);
 
-bool data_exists(hid_t fileId,const char * attr_name);
+LIBRARY_API bool group_exists(hid_t fileId,const char * attr_name);
+
+LIBRARY_API bool data_exists(hid_t fileId,const char * attr_name);
 
 
 #endif

--- a/src/numerics/APRFilter.hpp
+++ b/src/numerics/APRFilter.hpp
@@ -5,11 +5,14 @@
 #ifndef LIBAPR_APRFILTER_HPP
 #define LIBAPR_APRFILTER_HPP
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846 //added for clang-cl windows compilation as cmath.h does not define this in clang (not part of the standard)
+#endif
+
 #include "numerics/APRStencil.hpp"
 #include "numerics/APRTreeNumerics.hpp"
 
 #include<cmath>
-
 
 template<typename T>
 class ImageBuffer {
@@ -392,10 +395,6 @@ namespace APRFilter {
                 uint64_t z_in = (stencil_half[2] + (stencil_half[2] - z)) % stencil_shape[2];
                 uint64_t in_offset = z_in * x_num * y_num;
 
-                // copy slice at z_in to z
-#ifdef HAVE_OPENMP
-#pragma omp parallel for default(shared)
-#endif
                 for(int x = 0; x < x_num; ++x) {
                     std::copy(temp_vec.mesh.begin() + in_offset + x * y_num,
                               temp_vec.mesh.begin() + in_offset + (x+1) * y_num,
@@ -410,9 +409,6 @@ namespace APRFilter {
                 uint64_t in_offset = z_in * x_num * y_num;
 
                 // copy slice at z_in to z
-#ifdef HAVE_OPENMP
-#pragma omp parallel for default(shared)
-#endif
                 for(int x = 0; x < x_num; ++x) {
                     std::copy(temp_vec.mesh.begin() + in_offset + x * y_num,
                               temp_vec.mesh.begin() + in_offset + (x+1) * y_num,
@@ -423,9 +419,7 @@ namespace APRFilter {
 
             // fill slice at z with zeroes
             T pad_value = 0;
-#ifdef HAVE_OPENMP
-#pragma omp parallel for default(shared)
-#endif
+
             for(int x = 0; x < x_num; ++x) {
                 std::fill(temp_vec.mesh.begin() + out_offset + x * y_num,
                           temp_vec.mesh.begin() + out_offset + (x+1) * y_num,

--- a/src/numerics/APRRaycaster.cpp
+++ b/src/numerics/APRRaycaster.cpp
@@ -37,7 +37,6 @@ void
 APRRaycaster::getPos(int &dim1, int &dim2, float x_actual, float y_actual, float z_actual, int x_num, int y_num) {
     glm::vec2 pos = glmObjects->raytracedObject.worldToScreen(glmObjects->mvp, glm::vec3(x_actual, y_actual, z_actual),
                                                               x_num, y_num);
-
     dim1 = round(-pos.y);
     dim2 = round(-pos.x);
 }

--- a/src/numerics/APRRaycaster.cpp
+++ b/src/numerics/APRRaycaster.cpp
@@ -1,42 +1,42 @@
-
-#include "APRRaycaster.hpp"
-#include "vis/Camera.h"
-#include "vis/Object.h"
-#include "vis/RaytracedObject.h"
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-// Implementation of glm related stuff. Main reason is to avoid necessity to have glm header files installed
-// to use libAPR.
-
-struct APRRaycaster::GlmObjectsContainer {
-    RaytracedObject raytracedObject;
-    glm::mat4 mvp;
-};
-
-void APRRaycaster::initObjects(int imageWidth, int imageHeight, float radius, float theta, float x0, float y0,
-                               float z0, float x0f, float y0f, float z0f, float phi_) {
-    Camera cam = Camera(glm::vec3(x0 + radius*sin(phi), y0 + radius * sin(theta)*cos(phi_s), z0 + radius * cos(theta)*cos(phi_s)),
-                        glm::fquat(1.0f, 0.0f, 0.0f, 0.0f));
-    cam.setTargeted(glm::vec3(x0f, y0f, z0f));
-    cam.setPerspectiveCamera((float) imageWidth / (float) imageHeight, (float) (60.0f / 180.0f * M_PI), 0.5f, 70.0f);
-    glmObjects = new GlmObjectsContainer{
-            RaytracedObject(glm::vec3(0.0f, 0.0f, 0.0f), glm::fquat(1.0f, 0.0f, 0.0f, 0.0f)),
-            glm::mat4((*cam.getProjection()) * (*cam.getView()))
-    };
-}
-
-void APRRaycaster::killObjects() {
-    delete glmObjects;
-    glmObjects = nullptr;
-}
-
-void
-APRRaycaster::getPos(int &dim1, int &dim2, float x_actual, float y_actual, float z_actual, int x_num, int y_num) {
-    glm::vec2 pos = glmObjects->raytracedObject.worldToScreen(glmObjects->mvp, glm::vec3(x_actual, y_actual, z_actual),
-                                                              x_num, y_num);
-    dim1 = round(-pos.y);
-    dim2 = round(-pos.x);
-}
+//
+//#include "APRRaycaster.hpp"
+//#include "vis/Camera.h"
+//#include "vis/Object.h"
+//#include "vis/RaytracedObject.h"
+//
+//#ifndef M_PI
+//#define M_PI 3.14159265358979323846
+//#endif
+//
+//// Implementation of glm related stuff. Main reason is to avoid necessity to have glm header files installed
+//// to use libAPR.
+//
+//struct APRRaycaster::GlmObjectsContainer {
+//    RaytracedObject raytracedObject;
+//    glm::mat4 mvp;
+//};
+//
+//void APRRaycaster::initObjects(int imageWidth, int imageHeight, float radius, float theta, float x0, float y0,
+//                               float z0, float x0f, float y0f, float z0f, float phi_) {
+//    Camera cam = Camera(glm::vec3(x0 + radius*sin(phi), y0 + radius * sin(theta)*cos(phi_s), z0 + radius * cos(theta)*cos(phi_s)),
+//                        glm::fquat(1.0f, 0.0f, 0.0f, 0.0f));
+//    cam.setTargeted(glm::vec3(x0f, y0f, z0f));
+//    cam.setPerspectiveCamera((float) imageWidth / (float) imageHeight, (float) (60.0f / 180.0f * M_PI), 0.5f, 70.0f);
+//    glmObjects = new GlmObjectsContainer{
+//            RaytracedObject(glm::vec3(0.0f, 0.0f, 0.0f), glm::fquat(1.0f, 0.0f, 0.0f, 0.0f)),
+//            glm::mat4((*cam.getProjection()) * (*cam.getView()))
+//    };
+//}
+//
+//void APRRaycaster::killObjects() {
+//    delete glmObjects;
+//    glmObjects = nullptr;
+//}
+//
+//void
+//APRRaycaster::getPos(int &dim1, int &dim2, float x_actual, float y_actual, float z_actual, int x_num, int y_num) {
+//    glm::vec2 pos = glmObjects->raytracedObject.worldToScreen(glmObjects->mvp, glm::vec3(x_actual, y_actual, z_actual),
+//                                                              x_num, y_num);
+//    dim1 = round(-pos.y);
+//    dim2 = round(-pos.x);
+//}

--- a/src/numerics/APRRaycaster.hpp
+++ b/src/numerics/APRRaycaster.hpp
@@ -25,14 +25,8 @@
 
 #include "numerics/APRReconstruction.hpp"
 
-#ifdef WIN_COMPILE
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
 
-
-class LIBRARY_API APRRaycaster {
+class APRRaycaster {
 
 public:
 

--- a/src/numerics/APRRaycaster.hpp
+++ b/src/numerics/APRRaycaster.hpp
@@ -25,8 +25,14 @@
 
 #include "numerics/APRReconstruction.hpp"
 
+#ifdef WIN_COMPILE
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
 
-class APRRaycaster {
+
+class LIBRARY_API APRRaycaster {
 
 public:
 
@@ -54,8 +60,7 @@ public:
     std::string name = "raycast";
 
     template<typename S, typename V, class BinaryOperation>
-    void
-    perform_raycast(APR &apr, ParticleData<S> &particle_data, PixelData<V> &cast_views, BinaryOperation op);
+            void perform_raycast(APR &apr, ParticleData<S> &particle_data, PixelData<V> &cast_views, BinaryOperation op);
 
     template<typename S, typename V, typename T, class BinaryOperation>
     void perform_raycast_patch(APR &apr, ParticleData<S> &particle_data,

--- a/src/vis/Camera.h
+++ b/src/vis/Camera.h
@@ -9,7 +9,13 @@
 
 #include "Object.h"
 
-class Camera : Object {
+#ifdef WIN_COMPILE
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
+class LIBRARY_API Camera : Object {
     friend class RaytracedObject;
 
 protected:

--- a/src/vis/Object.h
+++ b/src/vis/Object.h
@@ -14,7 +14,13 @@
 #include <glm/gtx/matrix_operation.hpp>
 #include <vector>
 
-class Object {
+#ifdef WIN_COMPILE
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
+class LIBRARY_API Object {
 
 protected:
     glm::mat4 model = glm::diagonal4x4(glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));

--- a/src/vis/RaycastUtils.cpp
+++ b/src/vis/RaycastUtils.cpp
@@ -1,0 +1,38 @@
+//
+// Created by bevan on 28/03/2021.
+//
+
+#include "RaycastUtils.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+struct GlmObjectsContainer {
+    RaytracedObject raytracedObject;
+    glm::mat4 mvp;
+};
+
+void initObjects(GlmObjectsContainer* glmObjects, int imageWidth, int imageHeight, float radius, float theta, float x0, float y0,
+                 float z0, float x0f, float y0f, float z0f, float phi, float phi_s) {
+    Camera cam = Camera(glm::vec3(x0 + radius*sin(phi), y0 + radius * sin(theta)*cos(phi_s), z0 + radius * cos(theta)*cos(phi_s)),
+                        glm::fquat(1.0f, 0.0f, 0.0f, 0.0f));
+    cam.setTargeted(glm::vec3(x0f, y0f, z0f));
+    cam.setPerspectiveCamera((float) imageWidth / (float) imageHeight, (float) (60.0f / 180.0f * M_PI), 0.5f, 70.0f);
+    glmObjects = new GlmObjectsContainer{
+            RaytracedObject(glm::vec3(0.0f, 0.0f, 0.0f), glm::fquat(1.0f, 0.0f, 0.0f, 0.0f)),
+            glm::mat4((*cam.getProjection()) * (*cam.getView()))
+    };
+}
+
+void killObjects(GlmObjectsContainer* glmObjects) {
+    delete glmObjects;
+    glmObjects = nullptr;
+}
+
+void getPos(GlmObjectsContainer* glmObjects, int &dim1, int &dim2, float x_actual, float y_actual, float z_actual, int x_num, int y_num) {
+    glm::vec2 pos = glmObjects->raytracedObject.worldToScreen(glmObjects->mvp, glm::vec3(x_actual, y_actual, z_actual),
+                                                              x_num, y_num);
+    dim1 = round(-pos.y);
+    dim2 = round(-pos.x);
+}

--- a/src/vis/RaycastUtils.h
+++ b/src/vis/RaycastUtils.h
@@ -1,0 +1,26 @@
+//
+// Created by bevan on 28/03/2021.
+//
+
+#ifndef APR_RAYCASTUTILS_H
+#define APR_RAYCASTUTILS_H
+
+#include "Object.h"
+#include "Camera.h"
+#include "RaytracedObject.h"
+
+#ifdef WIN_COMPILE
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
+struct LIBRARY_API GlmObjectsContainer;
+
+LIBRARY_API void initObjects(GlmObjectsContainer* glmObjects, int imageWidth, int imageHeight, float radius, float theta, float x0, float y0,
+                 float z0, float x0f, float y0f, float z0f, float phi, float phi_s);
+
+LIBRARY_API void killObjects(GlmObjectsContainer* glmObjects);
+LIBRARY_API void getPos(GlmObjectsContainer* glmObjects, int &dim1, int &dim2, float x_actual, float y_actual, float z_actual, int x_num, int y_num);
+
+#endif //APR_RAYCASTUTILS_H

--- a/src/vis/RaytracedObject.cpp
+++ b/src/vis/RaytracedObject.cpp
@@ -6,6 +6,16 @@
 #include <iostream>
 #include <algorithm>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Implementation of glm related stuff. Main reason is to avoid necessity to have glm header files installed
+// to use libAPR.
+
+
+
+
 RaytracedObject::RaytracedObject(glm::vec3 position, glm::fquat rotation) : Object(position, rotation) { this->position = position; this->rotation = rotation; }
 
 std::pair<glm::vec3, glm::vec3>

--- a/src/vis/RaytracedObject.h
+++ b/src/vis/RaytracedObject.h
@@ -10,7 +10,13 @@
 #include "Camera.h"
 #include <glm/gtc/matrix_access.hpp>
 
-class RaytracedObject : public Object {
+#ifdef WIN_COMPILE
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
+class LIBRARY_API RaytracedObject : public Object {
 
 protected:
     glm::vec3 extent_min;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(buildTarget TARGET SRC)
     add_executable(${TARGET} ${SRC})
-    target_link_libraries(${TARGET} ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${GTEST_LIBRARIES} ${APR_BUILD_LIBRARY} Threads::Threads)
+    target_link_libraries(${TARGET} ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${GTEST_LIBRARIES} ${APR_BUILD_LIBRARY} Threads::Threads ${OPENMP_LINK})
     add_test( ${TARGET} ${TARGET} )
 endmacro(buildTarget)
 


### PR DESCRIPTION
Merged in windows compile then made some minor changes to try and get it going.

tmp_install was in a state I couldn't get compiling, (on windows nor Linux), as including APRRaycaseter.cpp into the source files for building the lib basicallyl pulls in the whole lib. Its not isolated like the other files.

I hence went back to the old model with treating the cpp like a header only include like the rest of the library. Not sure if that is satisfactory.

May be that we only want to cherry pick the changes I made to the vis files to allow windows compilation.