### PR TITLE
Expand particle sampling methods

### DIFF
--- a/benchmarks/BenchPipeline.cpp
+++ b/benchmarks/BenchPipeline.cpp
@@ -98,7 +98,7 @@ inline void bench_apr_pipeline(APR& apr,ParticleData<partsType>& parts,int num_r
 
         timer_steps.start_timer("sample_parts");
 
-        part_vec[r].sample_parts_from_img_downsampled(apr_vec[r],pipelineImage);
+        part_vec[r].sample_image(apr_vec[r], pipelineImage);
 
         timer_steps.stop_timer();
 

--- a/examples/Example_get_apr.cpp
+++ b/examples/Example_get_apr.cpp
@@ -79,7 +79,7 @@ int runAPR(cmdLineOptions options) {
     if(aprConverter.get_apr(apr, input_img)){
 
         ParticleData<uint16_t> particle_intensities;
-        particle_intensities.sample_parts_from_img_downsampled(apr,input_img); // sample your particles from your image
+        particle_intensities.sample_image(apr, input_img); // sample your particles from your image
         //Below is IO and outputting of the Implied Resolution Function through the Particle Cell level.
 
         //output

--- a/src/data_structures/APR/particles/PartCellData.hpp
+++ b/src/data_structures/APR/particles/PartCellData.hpp
@@ -96,18 +96,25 @@ public:
         }
     }
 
+    // kept for backwards compatibility
     template<typename imageType>
-    void sample_parts_from_img_downsampled(APR& apr,PixelData<imageType>& img){
+    [[deprecated("use PartCellData<DataType>::sample_image instead")]]
+    void sample_parts_from_img_downsampled(APR& apr, PixelData<imageType>& img){
+        sample_image(apr, img);
+    }
+
+    template<typename imageType>
+    void sample_image(APR& apr, PixelData<imageType>& img){
         auto sum = [](const float x, const float y) -> float { return x + y; };
         auto divide_by_8 = [](const float x) -> float { return x/8.0f; };
         sample_parts_from_img_downsampled_gen(apr, *this, img, sum, divide_by_8);
     }
 
     template<typename ImageType, typename BinaryOperator, typename UnaryOperator>
-    void sample_parts_from_img_downsampled(APR& apr,
-                                           PixelData<ImageType>& img,
-                                           BinaryOperator reduction_operator,
-                                           UnaryOperator constant_operator) {
+    void sample_image(APR& apr,
+                      PixelData<ImageType>& img,
+                      BinaryOperator reduction_operator,
+                      UnaryOperator constant_operator) {
         sample_parts_from_img_downsampled_gen(apr, *this, img, reduction_operator, constant_operator);
     }
 

--- a/src/data_structures/APR/particles/PartCellData.hpp
+++ b/src/data_structures/APR/particles/PartCellData.hpp
@@ -98,7 +98,17 @@ public:
 
     template<typename imageType>
     void sample_parts_from_img_downsampled(APR& apr,PixelData<imageType>& img){
-        sample_parts_from_img_downsampled_gen(apr,*this,img);
+        auto sum = [](const float x, const float y) -> float { return x + y; };
+        auto divide_by_8 = [](const float x) -> float { return x/8.0f; };
+        sample_parts_from_img_downsampled_gen(apr, *this, img, sum, divide_by_8);
+    }
+
+    template<typename ImageType, typename BinaryOperator, typename UnaryOperator>
+    void sample_parts_from_img_downsampled(APR& apr,
+                                           PixelData<ImageType>& img,
+                                           BinaryOperator reduction_operator,
+                                           UnaryOperator constant_operator) {
+        sample_parts_from_img_downsampled_gen(apr, *this, img, reduction_operator, constant_operator);
     }
 
 private:

--- a/src/data_structures/APR/particles/ParticleData.hpp
+++ b/src/data_structures/APR/particles/ParticleData.hpp
@@ -160,7 +160,7 @@ void sample_parts_from_img_downsampled_gen(APR& apr,ParticleDataType& parts,Pixe
 
     std::vector<PixelData<ImageType>> downsampled_img;
     //Down-sample the image for particle intensity estimation
-    downsamplePyrmaid(input_image, downsampled_img, apr.level_max(), apr.level_min());
+    downsamplePyramid(input_image, downsampled_img, apr.level_max(), apr.level_min());
 
     //aAPR.get_parts_from_img_alt(input_image,aAPR.particles_intensities);
     sample_parts_from_img_downsampled_gen(apr,parts,downsampled_img);
@@ -263,7 +263,7 @@ void sample_parts_from_img_downsampled_patch(APR& apr, ParticleDataType& parts, 
     auto it = apr.iterator();
     //Down-sample the image for particle intensity estimation at coarser resolutions
     std::vector<PixelData<ImageType>> img_by_level;
-    downsamplePyrmaid(input_image, img_by_level, apr.level_max(), apr.level_min());
+    downsamplePyramid(input_image, img_by_level, apr.level_max(), apr.level_min());
 
     for(int level = it.level_min(); level <= it.level_max(); ++level) {
 //        const int level_factor = std::pow(2,(int)it.level_max()-level);

--- a/src/data_structures/APR/particles/ParticleData.hpp
+++ b/src/data_structures/APR/particles/ParticleData.hpp
@@ -110,18 +110,28 @@ public:
         general_fill_level(apr,*this,true);
     }
 
-    template<typename imageType>
-    void sample_parts_from_img_downsampled(APR& apr, PixelData<imageType>& img){
+
+    // kept for backward compatibility
+    template<typename ImageType>
+    [[deprecated("use ParticleData<DataType>::sample_image instead")]]
+    void sample_parts_from_img_downsampled(APR& apr, PixelData<ImageType>& img){
+        sample_image(apr, img);
+    }
+
+
+    template<typename ImageType>
+    void sample_image(APR& apr, PixelData<ImageType>& img){
         auto sum = [](const float x, const float y) -> float { return x + y; };
         auto divide_by_8 = [](const float x) -> float { return x/8.0f; };
         sample_parts_from_img_downsampled_gen(apr, *this, img, sum, divide_by_8);
     }
 
+
     template<typename ImageType, typename BinaryOperator, typename UnaryOperator>
-    void sample_parts_from_img_downsampled(APR& apr,
-                                           PixelData<ImageType>& img,
-                                           BinaryOperator reduction_operator,
-                                           UnaryOperator constant_operator) {
+    void sample_image(APR& apr,
+                      PixelData<ImageType>& img,
+                      BinaryOperator reduction_operator,
+                      UnaryOperator constant_operator) {
 
         sample_parts_from_img_downsampled_gen(apr, *this, img, reduction_operator, constant_operator);
     }

--- a/src/data_structures/Mesh/PixelData.hpp
+++ b/src/data_structures/Mesh/PixelData.hpp
@@ -996,7 +996,7 @@ void const_upsample_img(PixelData<T>& input_us, PixelData<T>& input){
 
 
 template<typename T>
-void downsamplePyrmaid(PixelData<T> &original_image, std::vector<PixelData<T>> &downsampled, size_t l_max, size_t l_min) {
+void downsamplePyramid(PixelData<T> &original_image, std::vector<PixelData<T>> &downsampled, size_t l_max, size_t l_min) {
     downsampled.resize(l_max + 1); // each level is kept at same index
     downsampled.back().swap(original_image); // put original image at l_max index
 

--- a/src/io/TiffUtils.hpp
+++ b/src/io/TiffUtils.hpp
@@ -72,9 +72,9 @@ namespace TiffUtils {
         TiffType iType = TiffType::TIFF_INVALID;
         TIFF *iFile = nullptr;
         std::string iFileName = "";
-        uint32 iImgWidth = 0;
-        uint32 iImgHeight = 0;
-        uint32 iNumberOfDirectories = 0;
+        uint32_t iImgWidth = 0;
+        uint32_t iImgHeight = 0;
+        uint32_t iNumberOfDirectories = 0;
         unsigned short iSamplesPerPixel = 0;
         unsigned short iBitsPerSample = 0;
         unsigned short iSampleFormat = 0;

--- a/src/numerics/MeshNumerics.hpp
+++ b/src/numerics/MeshNumerics.hpp
@@ -570,7 +570,62 @@ public:
 
         return (elapsed_seconds);
     }
+
+
+    template<typename T, typename S>
+    static void find_boundary(PixelData<T>& input, PixelData<S>& output) {
+
+        output.initWithResize(input.y_num, input.x_num, input.z_num);
+
+#ifdef HAVE_OPENMP
+#pragma omp parallel for schedule(static) default(none) shared(input, output)
+#endif
+        for(int z = 0; z < input.z_num; ++z) {
+            for(int x = 0; x < input.x_num; ++x) {
+                for(int y = 0; y < input.y_num; ++y) {
+                    output.at(y, x, z) = 0;
+                    const auto val = input.at(y, x, z);
+
+                    if(val && (find_neighbor(input, y, x, z, val) != val)) {
+                        output.at(y, x, z) = val;
+                    }
+                }
+            }
+        }
+    }
+
+
+    template<typename T, typename S>
+    static void dilate(PixelData<T>& input, PixelData<S>& output) {
+
+        output.initWithResize(input.y_num, input.x_num, input.z_num);
+        output.copyFromMesh(input);
+
+#ifdef HAVE_OPENMP
+#pragma omp parallel for schedule(static) default(none) shared(input, output)
+#endif
+        for (int z = 0; z < input.z_num; ++z) {
+            for (int x = 0; x < input.x_num; ++x) {
+                for (int y = 0; y < input.y_num; ++y) {
+                    if (input.at(y, x, z) == 0) {
+                        output.at(y, x, z) = find_neighbor(input, y, x, z);
+                    }
+                }
+            }
+        }
+    }
 };
+
+template<typename T>
+inline T find_neighbor(PixelData<T>& input, const int y, const int x, const int z, const T comp_val = 0) {
+    if(y > 0 && (input.at(y-1, x, z) != comp_val)) return input.at(y-1, x, z);
+    if(y < input.y_num-1 && (input.at(y+1, x, z) != comp_val)) return input.at(y+1, x, z);
+    if(x > 0 && (input.at(y, x-1, z) != comp_val)) return input.at(y, x-1, z);
+    if(x < input.x_num-1 && (input.at(y, x+1, z) != comp_val)) return input.at(y, x+1, z);
+    if(z > 0 && (input.at(y, x, z-1) != comp_val)) return input.at(y, x, z-1);
+    if(z < input.z_num-1 && (input.at(y, x, z+1) != comp_val)) return input.at(y, x, z+1);
+    return comp_val;
+}
 
 
 #endif //PARTPLAY_MESHNUMERICS_HPP

--- a/src/numerics/MeshNumerics.hpp
+++ b/src/numerics/MeshNumerics.hpp
@@ -616,14 +616,27 @@ public:
     }
 };
 
+
 template<typename T>
-inline T find_neighbor(PixelData<T>& input, const int y, const int x, const int z, const T comp_val = 0) {
-    if(y > 0 && (input.at(y-1, x, z) != comp_val)) return input.at(y-1, x, z);
-    if(y < input.y_num-1 && (input.at(y+1, x, z) != comp_val)) return input.at(y+1, x, z);
-    if(x > 0 && (input.at(y, x-1, z) != comp_val)) return input.at(y, x-1, z);
-    if(x < input.x_num-1 && (input.at(y, x+1, z) != comp_val)) return input.at(y, x+1, z);
-    if(z > 0 && (input.at(y, x, z-1) != comp_val)) return input.at(y, x, z-1);
-    if(z < input.z_num-1 && (input.at(y, x, z+1) != comp_val)) return input.at(y, x, z+1);
+inline T find_neighbor(const PixelData<T>& input, const int y, const int x, const int z, const T comp_val = 0) {
+    if(y > 0 && (input.at(y-1, x, z) != comp_val)) {
+        return input.at(y-1, x, z);
+    }
+    if(y < input.y_num-1 && (input.at(y+1, x, z) != comp_val)) {
+        return input.at(y+1, x, z);
+    }
+    if(x > 0 && (input.at(y, x-1, z) != comp_val)) {
+        return input.at(y, x-1, z);
+    }
+    if(x < input.x_num-1 && (input.at(y, x+1, z) != comp_val)) {
+        return input.at(y, x+1, z);
+    }
+    if(z > 0 && (input.at(y, x, z-1) != comp_val)) {
+        return input.at(y, x, z-1);
+    }
+    if(z < input.z_num-1 && (input.at(y, x, z+1) != comp_val)) {
+        return input.at(y, x, z+1);
+    }
     return comp_val;
 }
 

--- a/test/APRTest.cpp
+++ b/test/APRTest.cpp
@@ -609,7 +609,7 @@ bool test_symmetry_pipeline(){
             aprConverter.get_apr(apr, img);
 
             ParticleData<uint16_t> parts;
-            parts.sample_parts_from_img_downsampled(apr, img);
+            parts.sample_image(apr, img);
 
             // get grad/scale/level/final level/final image. --> All should be symmetric!!! //could be nice to have a more elagant method for this.
             PixelData<float> scale = TiffUtils::getMesh<float>("local_intensity_scale_step.tif");
@@ -748,7 +748,7 @@ bool test_pipeline_different_sizes(TestData& test_data){
 
                 ParticleData<uint16_t> parts;
 
-                parts.sample_parts_from_img_downsampled(apr,input_data);
+                parts.sample_image(apr, input_data);
 
                 APRFile aprFile;
                 aprFile.open("test_small.apr","WRITE");
@@ -912,11 +912,11 @@ bool test_linear_access_create(TestData& test_data) {
 
     aprConverter.get_apr(apr,test_data.img_original);
 
-    particles_intensities.sample_parts_from_img_downsampled(apr,test_data.img_original);
+    particles_intensities.sample_image(apr, test_data.img_original);
 
     //test the partcell data structures
     PartCellData<uint16_t> partCellData_intensities;
-    partCellData_intensities.sample_parts_from_img_downsampled(apr,test_data.img_original);
+    partCellData_intensities.sample_image(apr, test_data.img_original);
 
     auto it = apr.iterator();
 
@@ -2887,7 +2887,7 @@ bool test_pipeline_u16(TestData& test_data){
 
     ParticleData<uint16_t> particles_intensities;
 
-    particles_intensities.sample_parts_from_img_downsampled(apr_c,test_data.img_original);
+    particles_intensities.sample_image(apr_c, test_data.img_original);
 
     //test the particles
     for (size_t j = 0; j < particles_intensities.size(); ++j) {
@@ -2951,7 +2951,7 @@ bool test_pipeline_u16_blocked(TestData& test_data) {
     ParticleData<uint16_t> parts;
     ParticleData<uint16_t> partsBatch;
 
-    parts.sample_parts_from_img_downsampled(apr, test_data.img_original);
+    parts.sample_image(apr, test_data.img_original);
     partsBatch.sample_parts_from_img_blocked(aprBatch, test_data.filename, z_block_size, z_ghost);
 
     for(size_t i = 0; i < apr.total_number_particles(); ++i) {
@@ -2998,7 +2998,7 @@ bool test_pipeline_bound(TestData& test_data,float rel_error){
 
     aprConverter.get_apr(apr,test_data.img_original);
 
-    particles_intensities.sample_parts_from_img_downsampled(apr,test_data.img_original);
+    particles_intensities.sample_image(apr, test_data.img_original);
 
     PixelData<uint16_t> pc_recon;
     APRReconstruction::reconstruct_constant(apr,pc_recon,particles_intensities);

--- a/test/APRTest.cpp
+++ b/test/APRTest.cpp
@@ -1383,7 +1383,7 @@ bool test_apr_tree(TestData& test_data) {
 
     std::vector<PixelData<float>> downsampled_img;
     //Down-sample the image for particle intensity estimation
-    downsamplePyrmaid(pc_image, downsampled_img, test_data.apr.level_max(), test_data.apr.level_min()-1);
+    downsamplePyramid(pc_image, downsampled_img, test_data.apr.level_max(), test_data.apr.level_min() - 1);
 
 
     auto tree_it_random = test_data.apr.random_tree_iterator();
@@ -3140,7 +3140,7 @@ bool test_reconstruct_patch(TestData &test_data, const int level_delta = 0) {
     if (level_delta < 0) {
         std::vector<PixelData<float>> img_pyramid;
         const int level = test_data.apr.level_max() + patch.level_delta;
-        downsamplePyrmaid(recon_full, img_pyramid, test_data.apr.level_max(), level);
+        downsamplePyramid(recon_full, img_pyramid, test_data.apr.level_max(), level);
         recon_full.swap(img_pyramid[level]);
     }
 

--- a/test/MeshDataTest.cpp
+++ b/test/MeshDataTest.cpp
@@ -483,7 +483,7 @@ namespace {
         for (size_t i = 0; i < m.mesh.size(); ++i) m.mesh[i] = i + 1;
 
         std::vector<PixelData<float>> ds;
-        downsamplePyrmaid(m, ds, 3, 1);
+        downsamplePyramid(m, ds, 3, 1);
 
         ASSERT_EQ(ds.size(), 4);
         ASSERT_EQ(ds[3].mesh.size(), 4 * 4 * 4); // original input


### PR DESCRIPTION
Rename ParticleData / PartCellData method `sample_parts_from_img_downsampled` -> `sample_image` (old method is kept with a deprecation warning).

Generalize `sample_image` methods to allow specifying the reduction operators via templates.

Add experimental method to sample (separately) the boundaries and interiors of objects in label images.

