### PR TITLE
Update GPU access initialization methods

### DIFF
--- a/benchmarks/BenchCudaAccessInit.cpp
+++ b/benchmarks/BenchCudaAccessInit.cpp
@@ -70,12 +70,12 @@ inline void bench_access_full(APR& apr,ParticleData<partsType>& parts,int num_re
 
     for(int r = 0; r < 5; ++r) {
         auto access = apr.gpuAPRHelper();
-        access.init_gpu();
+        access.init_gpu(true);
         error_check ( cudaDeviceSynchronize() )
         error_check( cudaGetLastError() )
 
         auto tree_access = apr.gpuTreeHelper();
-        tree_access.init_gpu();
+        tree_access.init_gpu(true);
         error_check ( cudaDeviceSynchronize() )
         error_check( cudaGetLastError() )
     }
@@ -84,14 +84,14 @@ inline void bench_access_full(APR& apr,ParticleData<partsType>& parts,int num_re
     for(int r = 0; r < num_rep; ++r) {
         timer2.start_timer("apr access");
         auto access = apr.gpuAPRHelper();
-        access.init_gpu();
+        access.init_gpu(true);
         error_check ( cudaDeviceSynchronize() )
         timer2.stop_timer();
         apr_time += timer2.timings.back();
 
         timer2.start_timer("tree access");
         auto tree_access = apr.gpuTreeHelper();
-        tree_access.init_gpu();
+        tree_access.init_gpu(true);
         error_check ( cudaDeviceSynchronize() )
         timer2.stop_timer();
         tree_time += timer2.timings.back();
@@ -115,12 +115,12 @@ inline void bench_access_partial(APR& apr,ParticleData<partsType>& parts,int num
 
     for(int r = 0; r < 5; ++r) {
         auto tree_access = apr.gpuTreeHelper();
-        tree_access.init_gpu();
+        tree_access.init_gpu(true);
         error_check ( cudaDeviceSynchronize() )
         error_check( cudaGetLastError() )
 
         auto access = apr.gpuAPRHelper();
-        access.init_gpu(tree_access);
+        access.init_gpu(tree_access, true);
         error_check ( cudaDeviceSynchronize() )
         error_check( cudaGetLastError() )
     }
@@ -130,14 +130,14 @@ inline void bench_access_partial(APR& apr,ParticleData<partsType>& parts,int num
 
         timer2.start_timer("tree access");
         auto tree_access = apr.gpuTreeHelper();
-        tree_access.init_gpu();
+        tree_access.init_gpu(true);
         error_check ( cudaDeviceSynchronize() )
         timer2.stop_timer();
         tree_time += timer2.timings.back();
 
         timer2.start_timer("apr access");
         auto access = apr.gpuAPRHelper();
-        access.init_gpu(tree_access);
+        access.init_gpu(tree_access, true);
         error_check ( cudaDeviceSynchronize() )
         timer2.stop_timer();
         apr_time += timer2.timings.back();

--- a/src/data_structures/APR/APR.hpp
+++ b/src/data_structures/APR/APR.hpp
@@ -79,6 +79,22 @@ public:
         }
         return GPUAccessHelper(gpuTreeAccess,linearAccessTree);
     }
+
+
+    /**
+     * Initialize GPU access and copy data to device
+     * @param with_tree     include the tree access
+     */
+    void init_cuda(bool with_tree=true) {
+        auto apr_helper = gpuAPRHelper();
+        if(with_tree) {
+            auto tree_helper = gpuTreeHelper();
+            tree_helper.init_gpu();
+            apr_helper.init_gpu(tree_helper);
+        } else {
+            apr_helper.init_gpu();
+        }
+    }
 #endif
 
 

--- a/src/data_structures/APR/access/GPUAccess.hpp
+++ b/src/data_structures/APR/access/GPUAccess.hpp
@@ -17,6 +17,7 @@ protected:
 
     class GPUAccessImpl;
     std::unique_ptr<GPUAccessImpl> data;
+    bool initialized = false;
 
 public:
 
@@ -61,20 +62,26 @@ public:
     uint64_t* get_xz_end_vec_ptr();
     uint64_t* get_level_xz_vec_ptr();
 
-    void init_gpu(){
-        gpuAccess->init_y_vec(linearAccess->y_vec);
-        gpuAccess->init_level_xz_vec(linearAccess->level_xz_vec);
-        gpuAccess->init_xz_end_vec(linearAccess->xz_end_vec);
-        gpuAccess->genInfo = linearAccess->genInfo;
-        gpuAccess->copy2Device();
+    void init_gpu(bool force=false){
+        if(force || !gpuAccess->initialized) {
+            gpuAccess->init_y_vec(linearAccess->y_vec);
+            gpuAccess->init_level_xz_vec(linearAccess->level_xz_vec);
+            gpuAccess->init_xz_end_vec(linearAccess->xz_end_vec);
+            gpuAccess->genInfo = linearAccess->genInfo;
+            gpuAccess->copy2Device();
+            gpuAccess->initialized = true;
+        }
     }
 
-    void init_gpu(GPUAccessHelper& tree_access){
-        gpuAccess->init_y_vec(linearAccess->y_vec);
-        gpuAccess->init_level_xz_vec(linearAccess->level_xz_vec);
-        gpuAccess->init_xz_end_vec(linearAccess->xz_end_vec);
-        gpuAccess->genInfo = linearAccess->genInfo;
-        gpuAccess->copy2Device(total_number_particles(tree_access.level_max()), tree_access.gpuAccess);
+    void init_gpu(GPUAccessHelper& tree_access, bool force=false){
+        if(force || !gpuAccess->initialized) {
+            gpuAccess->init_y_vec(linearAccess->y_vec);
+            gpuAccess->init_level_xz_vec(linearAccess->level_xz_vec);
+            gpuAccess->init_xz_end_vec(linearAccess->xz_end_vec);
+            gpuAccess->genInfo = linearAccess->genInfo;
+            gpuAccess->copy2Device(total_number_particles(tree_access.level_max()), tree_access.gpuAccess);
+            gpuAccess->initialized = true;
+        }
     }
 
     void copy2Host() {


### PR DESCRIPTION
- adds an `init_cuda` method to the `APR` class
- adds a flag `initialized` to `GPUAccess` and checks to avoid unnecessary transfers
