### PR TITLE
Few fixes for CUDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,8 @@ cmake-build-debug/
 cmake-build-release/
 cmake-build*
 xcode*
+build-cmake-debug/
+build-cmake-release/
 #####
 # Xcode private settings (window sizes, bookmarks, breakpoints, custom executables, smart groups)
 #

--- a/src/algorithm/APRConverter.hpp
+++ b/src/algorithm/APRConverter.hpp
@@ -441,7 +441,9 @@ inline bool APRConverter<ImageType>::get_apr(APR &aAPR, PixelData<T>& input_imag
 
     initPipelineAPR(aAPR, input_image.y_num, input_image.x_num, input_image.z_num);
 
-#ifndef APR_USE_CUDA
+// TODO: Current pipeline is temporarily turned off,
+//       After revising a CUDA pipeline remove "#if true // " part.
+#if true // #ifndef APR_USE_CUDA
 
     total_timer.start_timer("full_pipeline");
 

--- a/src/algorithm/APRParameters.hpp
+++ b/src/algorithm/APRParameters.hpp
@@ -33,7 +33,6 @@ public:
 
     // additional pipeline parameters
     bool reflect_bc_lis = true;
-    int extra_smooth = 0;
     bool check_input = false;
     bool swap_dimensions = false;
     bool neighborhood_optimization = true;

--- a/src/algorithm/LocalIntensityScale.hpp
+++ b/src/algorithm/LocalIntensityScale.hpp
@@ -109,19 +109,6 @@ void get_local_intensity_scale(PixelData<float> &local_scale_temp, PixelData<flo
             calc_sat_mean_z(local_scale_temp, win_z2);
         }
 
-        // second average for extra smoothing
-        if(par.extra_smooth) {
-            if (active_y) {
-                calc_sat_mean_y(local_scale_temp, par.extra_smooth);
-            }
-            if (active_x) {
-                calc_sat_mean_x(local_scale_temp, par.extra_smooth);
-            }
-            if (active_z) {
-                calc_sat_mean_z(local_scale_temp, par.extra_smooth);
-            }
-        }
-
         rescale_var(local_scale_temp, var_rescale);
         timer.stop_timer();
 

--- a/src/data_structures/APR/access/GPUAccess.cu
+++ b/src/data_structures/APR/access/GPUAccess.cu
@@ -157,6 +157,10 @@ template class ParticleDataGpu<float>;
 template class ParticleDataGpu<double>;
 template class ParticleDataGpu<int>;
 template class ParticleDataGpu<uint64_t>;
+template class ParticleDataGpu<uint32_t>;
+template class ParticleDataGpu<int8_t>;
+template class ParticleDataGpu<int16_t>;
+template class ParticleDataGpu<int64_t>;
 
 __global__ void fill_y_vec_max_level(const uint64_t* level_xz_vec,
                                      const uint64_t* xz_end_vec,

--- a/test/APRTest.cpp
+++ b/test/APRTest.cpp
@@ -2879,7 +2879,7 @@ bool test_pipeline_u16(TestData& test_data){
     }
 
     APR apr_c;
-    aprConverter.initPipelineAPR(apr_c, test_data.img_original.y_num, test_data.img_original.x_num, test_data.img_original.z_num);
+    aprConverter.initPipelineAPR(apr_c, test_data.img_original);
 
     aprConverter.get_apr_custom_grad_scale(apr_c,gradient_saved,scale_saved);
 


### PR DESCRIPTION
Hello,

Here are few fixes:
1. Removed 'extra_smooth' parameter as agreed with Joel some time ago (+/- 1 year ;-) ).
2. Added missing explicit instantiations for types needed by APRTest.cpp 
3. Switching off two big pipeline test - I will work on them in the near future and enable when whole pipeline is working again...
4. Because pipeline is not working I turned it off  in APRConverter.cpp (so CPU is always used regardless off APR_USE_CUDA). It allows to have working tests and progress on CUDA impl. 

Those changes allows to compile LibAPR and run tests for CUDA  which is minimum for later development and would be nice to have it on develop.
