### PR TITLE
Fix cuda build

### DIFF
--- a/src/data_structures/APR/access/GPUAccess.cu
+++ b/src/data_structures/APR/access/GPUAccess.cu
@@ -162,10 +162,6 @@ template class ParticleDataGpu<int8_t>;
 template class ParticleDataGpu<int16_t>;
 template class ParticleDataGpu<int64_t>;
 
-template class ParticleDataGpu<int8_t>;
-template class ParticleDataGpu<int16_t>;
-template class ParticleDataGpu<uint32_t>;
-template class ParticleDataGpu<int64_t>;
 
 __global__ void fill_y_vec_max_level(const uint64_t* level_xz_vec,
                                      const uint64_t* xz_end_vec,


### PR DESCRIPTION
Since same changes introduced in PR #169 and #163  ParticleDataGpu class was explicitly instantiated more than once.

