### PR TITLE
PixelDataDim structure

### DIFF
--- a/src/data_structures/Mesh/PixelData.hpp
+++ b/src/data_structures/Mesh/PixelData.hpp
@@ -29,6 +29,39 @@
 #include "misc/CudaMemory.cuh"
 #endif
 
+struct PixelDataDim {
+    size_t y;
+    size_t x;
+    size_t z;
+
+    PixelDataDim(size_t y, size_t x, size_t z) : y(y), x(x), z(z) {}
+
+    size_t size() const { return y * x * z; }
+
+    PixelDataDim operator+(const PixelDataDim &rhs) const { return {y + rhs.y, x + rhs.x, z + rhs.z}; }
+    PixelDataDim operator-(const PixelDataDim &rhs) const { return {y - rhs.y, x - rhs.x, z - rhs.z}; }
+
+    template<typename INTEGER>
+    constexpr typename std::enable_if<std::is_integral<INTEGER>::value, PixelDataDim>::type
+    operator+(INTEGER i) const { return {y + i, x + i, z + i}; }
+
+    template<typename INTEGER>
+    constexpr typename std::enable_if<std::is_integral<INTEGER>::value, PixelDataDim>::type
+    operator-(INTEGER i) const { return *this + (-i); }
+
+    friend bool operator==(const PixelDataDim& lhs, const PixelDataDim& rhs) {
+        return (lhs.x == rhs.x) && (lhs.y == rhs.y) && (lhs.z == rhs.z);
+    }
+    friend bool operator!=(const PixelDataDim& lhs, const PixelDataDim& rhs) {
+        return !(lhs == rhs);
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const PixelDataDim &obj) {
+        os << "{" << obj.y << ", " << obj.x << ", " << obj.z << "}";
+        return os;
+    }
+};
+
 template <typename T>
 class ArrayWrapper
 {
@@ -436,6 +469,13 @@ public :
     PixelData(const PixelData<U> &aMesh, bool aShouldCopyData, bool aUsedPinnedMemory = false) {
         init(aMesh.y_num, aMesh.x_num, aMesh.z_num, aUsedPinnedMemory);
         if (aShouldCopyData) std::copy(aMesh.mesh.begin(), aMesh.mesh.end(), mesh.begin());
+    }
+
+    /**
+     * Returns dimensions of PixelData
+     */
+    PixelDataDim getDimension() const {
+        return {static_cast<size_t>(y_num), static_cast<size_t>(x_num), static_cast<size_t>(z_num)};
     }
 
     /**

--- a/test/MeshDataTest.cpp
+++ b/test/MeshDataTest.cpp
@@ -24,6 +24,64 @@ namespace {
         VectorData<MESH_TYPE> m;
     };
 
+    TEST(MeshDataSimpleTest, PixelDataDimTest) {
+        // size provided
+        {
+            PixelData<int> md(10, 20, 30);
+            auto d = md.getDimension();
+
+            ASSERT_EQ(d.y, 10);
+            ASSERT_EQ(d.x, 20);
+            ASSERT_EQ(d.z, 30);
+            ASSERT_EQ(d.size(), 10*20*30);
+        }
+        { // adding int to all dims
+
+            PixelDataDim x = {1,2,3};
+            auto d = x + 1;
+            ASSERT_EQ(d.y, 2);
+            ASSERT_EQ(d.x, 3);
+            ASSERT_EQ(d.z, 4);
+        }
+        { // subtract int from all dims
+
+            const PixelDataDim x = {1,2,3};
+            auto d = x - 1;
+            ASSERT_EQ(d.y, 0);
+            ASSERT_EQ(d.x, 1);
+            ASSERT_EQ(d.z, 2);
+        }
+        { // adding another PixelDataDim
+
+            PixelDataDim x = {1,2,3};
+            const PixelDataDim y = {5, 10, 15};
+            auto d = x + y;
+            ASSERT_EQ(d.y, 6);
+            ASSERT_EQ(d.x, 12);
+            ASSERT_EQ(d.z, 18);
+        }
+        { // subtract another PixelDataDim
+
+            const PixelDataDim x = {5, 10, 15};
+            PixelDataDim y = {1, 2, 3};
+            auto d = x - y;
+            ASSERT_EQ(d.y, 4);
+            ASSERT_EQ(d.x, 8);
+            ASSERT_EQ(d.z, 12);
+        }
+        { // compare two PixelDataDim structures
+            const PixelDataDim x = {2, 3, 5};
+            const PixelDataDim y = {2, 3, 5};
+            const PixelDataDim z = {3, 4, 5};
+
+            ASSERT_TRUE(x == y);
+            ASSERT_FALSE(x != y);
+
+            ASSERT_FALSE(x == z);
+            ASSERT_TRUE(x != z);
+        }
+    }
+
     TEST_F(VectorDataTest, InitTest) {
         // Check initialize and resize and size are working correctly
 

--- a/test/TestTools.hpp
+++ b/test/TestTools.hpp
@@ -81,8 +81,8 @@ inline int compareMeshes(const PixelData<T> &expected, const PixelData<T> &teste
 
 
 template <typename T>
-inline size_t compareParticles(const ParticleData<T> &expected, const ParticleData<T> &tested, double maxError = 0.0001, int maxNumOfErrPrinted = 10) {
-    size_t cnt = 0;
+inline int64_t compareParticles(const ParticleData<T> &expected, const ParticleData<T> &tested, double maxError = 0.0001, int maxNumOfErrPrinted = 10) {
+    int64_t cnt = 0;
     if(expected.size() != tested.size()) {
         std::cerr << "ERROR compareParticles: sizes differ!" << std::endl;
         cnt++;


### PR DESCRIPTION
Introduced PixelDataDim structure with dimensions of PixelData.

I'm using it currently in CUDA code since need to sometimes pass dimensions through multiple function call chains and it is annoying to always pass 3 params like ```foo(size_t ylen, size_t xLen, size_t zLen, ...)``` instead one meaningful ```foo(PixelDataDim dims)```. 

Dear reviewer! 
This is 'living structure' and I'm updating it as needed - I'm aware that it might be incomplete or some things should be done differently. It  will also (if used in other places) allow easy transition from YXZ ordering to XYZ in future.
 
 