### PR TITLE
set GenInfo pointers of access members in copy constructor

### DIFF
--- a/src/data_structures/APR/APR.hpp
+++ b/src/data_structures/APR/APR.hpp
@@ -196,6 +196,16 @@ public:
         apr_initialized_random = apr2copy.apr_initialized_random;
         tree_initialized_random = apr2copy.tree_initialized_random;
 
+        linearAccess.genInfo = &aprInfo;
+        linearAccessTree.genInfo = &treeInfo;
+        apr_access.genInfo = &aprInfo;
+        tree_access.genInfo = &treeInfo;
+
+#ifdef APR_USE_CUDA
+        gpuAccess.genInfo = &aprInfo;
+        gpuTreeAccess.genInfo = &treeInfo;
+#endif
+
     }
 
     void initialize_linear(){


### PR DESCRIPTION
Fixes an issue where using a copied APR would sometimes result in errors due to the `GenInfo*` of access classes pointing to old (potentially deleted) memory.